### PR TITLE
Re-add blocking areas(zones) by enemies

### DIFF
--- a/source/game/ai/ai_aas_route_cache.h
+++ b/source/game/ai/ai_aas_route_cache.h
@@ -444,8 +444,12 @@ public:
 		return false;
 	}
 
-	inline bool AreaDisabled( int areaNum ) {
+	inline bool AreaDisabled( int areaNum ) const {
 		return areasDisabledStatus[areaNum].CurrStatus() || ( aasWorld.AreaSettings()[areaNum].areaflags & AREA_DISABLED );
+	}
+
+	inline bool AreaTemporarilyDisabled( int areaNum ) const {
+		return areasDisabledStatus[areaNum].CurrStatus();
 	}
 
 	struct DisableZoneRequest {

--- a/source/game/ai/ai_aas_world.h
+++ b/source/game/ai/ai_aas_world.h
@@ -259,6 +259,9 @@ class AiAasWorld
 
 	int *face2DProjVertexNums;     // Elements #i*2, #i*2+1 contain numbers of vertices of a 2d face proj for face #i
 
+	int *areaMapLeafListOffsets;    // An element #i contains an offset of leafs list data in the joint data
+	int *areaMapLeafsData;          // Contains area map (collision/vis) leafs lists, each one is prepended by the length
+
 	static AiAasWorld *instance;
 
 	AiAasWorld() {
@@ -283,6 +286,8 @@ class AiAasWorld
 	void ComputeLogicalAreaClusters();
     // Computes vertices of top 2D face projections
 	void ComputeFace2DProjVertices();
+	// Computes map (collision/vis) leafs for areas
+	void ComputeAreasLeafsLists();
 
 	void TrySetAreaLedgeFlags( int areaNum );
 	void TrySetAreaWallFlags( int areaNum );
@@ -462,6 +467,11 @@ public:
 	}
 
 	inline int *Face2DProjVertexNums() const { return face2DProjVertexNums; }
+
+	inline const int *AreaMapLeafsList( int areaNum ) const {
+		assert( areaNum >= 0 && areaNum < numareas );
+		return areaMapLeafsData + areaMapLeafListOffsets[areaNum];
+	}
 };
 
 #endif

--- a/source/game/ai/ai_base_enemy_pool.h
+++ b/source/game/ai/ai_base_enemy_pool.h
@@ -108,32 +108,59 @@ class Enemy
 	friend class AiBaseEnemyPool;
 	class AiBaseEnemyPool *parent;
 
+	// Intrusive list links (an instance can be linked to many lists at the same time)
+	struct Links {
+		Enemy *next, *prev;
+
+		void Clear() {
+			next = prev = nullptr;
+		}
+	};
+
+	enum { TRACKED_LIST_INDEX, ACTIVE_LIST_INDEX };
+	Links listLinks[2];
+
 	float weight;
 	float avgPositiveWeight;
 	float maxPositiveWeight;
 	unsigned positiveWeightsCount;
 
+	int entNum;
+	float scoreAsActiveEnemy;
+
 	int64_t registeredAt;
 
-	// Same as front() of lastSeenPositions, used for faster access
-	Vec3 lastSeenPosition;
-	// Same as front() of lastSeenVelocities, used for faster access
-	Vec3 lastSeenVelocity;
 	// Same as front() of lastSeenTimestamps, used for faster access
 	int64_t lastSeenAt;
+	// Same as front() of lastSeenOrigins, used for faster access
+	Vec3 lastSeenOrigin;
+	// Same as front() of lastSeenVelocities, used for faster access
+	Vec3 lastSeenVelocity;
 
+	Enemy *NextInTrackedList() { return listLinks[TRACKED_LIST_INDEX].next; }
+	Enemy *NextInActiveList() { return listLinks[ACTIVE_LIST_INDEX].next; }
+
+	inline bool IsInList( int listIndex ) const;
 public:
 	const edict_t *ent;  // If null, the enemy slot is unused
 
 	inline Enemy()
-		: parent( nullptr ), lastSeenPosition( NAN, NAN, NAN ), lastSeenVelocity( NAN, NAN, NAN ), ent( nullptr ) {
+		: parent( nullptr ), entNum( -1 ), lastSeenOrigin( NAN, NAN, NAN ), lastSeenVelocity( NAN, NAN, NAN ) {
 		Clear();
 	}
 
-	static constexpr unsigned MAX_TRACKED_POSITIONS = 16;
+	const Enemy *NextInTrackedList() const { return listLinks[TRACKED_LIST_INDEX].next; }
+	const Enemy *NextInActiveList() const { return listLinks[ACTIVE_LIST_INDEX].next; }
+
+	inline bool IsInTrackedList() const { return IsInList( TRACKED_LIST_INDEX ); }
+
+	inline bool IsInActiveList() const { return IsInList( ACTIVE_LIST_INDEX ); }
+
+	static constexpr unsigned MAX_TRACKED_SNAPSHOTS = 16;
 
 	void Clear();
 	void OnViewed( const float *specifiedOrigin = nullptr );
+	void InitAndLink( const edict_t *ent, const float *specifiedOrigin = nullptr );
 
 	inline const char *Nick() const {
 		if( !ent ) {
@@ -144,6 +171,8 @@ public:
 
 	inline float AvgWeight() const { return avgPositiveWeight; }
 	inline float MaxWeight() const { return maxPositiveWeight; }
+
+	inline int EntNum() const { return entNum; }
 
 	inline bool HasQuad() const { return ::HasQuad( ent ); }
 	inline bool HasShell() const { return ::HasShell( ent ); }
@@ -178,7 +207,7 @@ public:
 	}
 
 	inline int64_t LastSeenAt() const { return lastSeenAt; }
-	inline const Vec3 &LastSeenPosition() const { return lastSeenPosition; }
+	inline const Vec3 &LastSeenOrigin() const { return lastSeenOrigin; }
 	inline const Vec3 &LastSeenVelocity() const { return lastSeenVelocity; }
 
 	inline int64_t LastAttackedByTime() const;
@@ -190,16 +219,23 @@ public:
 
 	inline Vec3 Angles() const { return Vec3( ent->s.angles ); }
 
-	struct Snapshot {
-		const Vec3 origin;
-		const Vec3 velocity;
-		int64_t timestamp;
+	class alignas ( 4 )Snapshot {
+		Int64Align4 timestamp;
+		int16_t packedOrigin[3];
+		int16_t packedVelocity[3];
+	public:
+		Snapshot( const vec3_t origin_, const vec3_t velocity_, int64_t timestamp_ ) {
+			this->timestamp = timestamp;
+			SetPacked4uVec( origin_, this->packedOrigin );
+			SetPacked4uVec( velocity_, this->packedVelocity );
+		}
 
-		Snapshot( const vec3_t origin_, const vec3_t velocity_, unsigned timestamp_ )
-			: origin( origin_ ), velocity( velocity_ ), timestamp( timestamp_ ) {}
+		int64_t Timestamp() const { return timestamp; }
+		Vec3 Origin() const { return GetUnpacked4uVec( packedOrigin ); }
+		Vec3 Velocity() const { return GetUnpacked4uVec( packedVelocity ); }
 	};
 
-	typedef StaticDeque<Snapshot, MAX_TRACKED_POSITIONS> SnapshotsQueue;
+	typedef StaticDeque<Snapshot, MAX_TRACKED_SNAPSHOTS> SnapshotsQueue;
 	SnapshotsQueue lastSeenSnapshots;
 };
 
@@ -212,7 +248,9 @@ class AttackStats
 
 	static_assert( ( MAX_KEPT_FRAMES & ( MAX_KEPT_FRAMES - 1 ) ) == 0, "Should be a power of 2 for fast modulo computation" );
 
-	float frameDamages[MAX_KEPT_FRAMES];
+	// A damage is saturated up to 255 units.
+	// Storing greater values not only does not make sense, but leads to non-efficient memory usage/cache access.
+	uint8_t frameDamages[MAX_KEPT_FRAMES];
 
 	unsigned frameIndex;
 	unsigned totalAttacks;
@@ -237,10 +275,10 @@ public:
 
 	// Call it once in a game frame
 	void Frame() {
-		float overwrittenDamage = frameDamages[frameIndex];
+		auto overwrittenDamage = frameDamages[frameIndex];
 		frameIndex = ( frameIndex + 1 ) % MAX_KEPT_FRAMES;
 		totalDamage -= overwrittenDamage;
-		frameDamages[frameIndex] = 0.0f;
+		frameDamages[frameIndex] = 0;
 		if( overwrittenDamage > 0 ) {
 			totalAttacks--;
 		}
@@ -248,7 +286,7 @@ public:
 
 	// Call it after Frame() in the same frame
 	void OnDamage( float damage ) {
-		frameDamages[frameIndex] = damage;
+		frameDamages[frameIndex] = (uint8_t)std::min( damage, 255.0f );
 		totalDamage += damage;
 		totalAttacks++;
 		lastDamageAt = level.time;
@@ -263,37 +301,33 @@ public:
 
 class AiBaseEnemyPool : public AiFrameAwareUpdatable
 {
+	friend class Enemy;
 public:
-	static constexpr unsigned MAX_TRACKED_ENEMIES = 10;
 	static constexpr unsigned MAX_TRACKED_ATTACKERS = 5;
 	static constexpr unsigned MAX_TRACKED_TARGETS = 5;
-	// Ensure we always will have at least 3 free slots for new enemies
-	// (quad/shell owners and carrier) FOR MAXIMAL SKILL
-	static_assert( MAX_TRACKED_ATTACKERS + 3 <= MAX_TRACKED_ENEMIES, "Leave at least 3 free slots for ordinary enemies" );
-	static_assert( MAX_TRACKED_TARGETS + 3 <= MAX_TRACKED_ENEMIES, "Leave at least 3 free slots for ordinary enemies" );
 
-	static constexpr unsigned NOT_SEEN_TIMEOUT = 4000;
-	static constexpr unsigned ATTACKER_TIMEOUT = 3000;
-	static constexpr unsigned TARGET_TIMEOUT = 3000;
+	// If an enemy has not been seen for this period, it gets unlinked and completely forgotten
+	// and thus cannot block an area (in general and not AAS sense) anymore.
+	static constexpr unsigned NOT_SEEN_UNLINK_TIMEOUT = 8000;
+	// If an enemy has not been seen for this period, it gets unlinked.
+	static constexpr unsigned NOT_SEEN_SUGGEST_TIMEOUT = 4000;
+	// An attacker gets evicted/forgotten if there were no hits during this period.
+	static constexpr unsigned ATTACKER_TIMEOUT = 4000;
+	// A target gets evicted/forgotten if there were no hits/selection as a target during this period.
+	static constexpr unsigned TARGET_TIMEOUT = 4000;
 
 	static constexpr unsigned MAX_ACTIVE_ENEMIES = 3;
 
 private:
 	float avgSkill; // (0..1)
-	float decisionRandom; // [0, 1]
-	int64_t decisionRandomUpdateAt;
 
-	// All known (viewed and not forgotten) enemies
-	Enemy trackedEnemies[MAX_TRACKED_ENEMIES];
-	// Active enemies (potential targets) in order of importance
-	StaticVector<Enemy *, MAX_ACTIVE_ENEMIES> activeEnemies;
-	// Scores of active enemies updated during enemies assignation
-	// (a single vector of pairs (enemy, score) can't be used
-	// because external users need a vector of enemies only)
-	StaticVector<float, MAX_ACTIVE_ENEMIES> activeEnemiesScores;
+	// An i-th element corresponds to i-th entity
+	Enemy entityToEnemyTable[MAX_EDICTS];
 
-	unsigned trackedEnemiesCount;
-	const unsigned maxTrackedEnemies;
+	// List heads for tracked and active enemies lists
+	Enemy *listHeads[2];
+
+	unsigned numTrackedEnemies;
 	const unsigned maxTrackedAttackers;
 	const unsigned maxTrackedTargets;
 	const unsigned maxActiveEnemies;
@@ -305,10 +339,9 @@ private:
 	StaticVector<AttackStats, MAX_TRACKED_ATTACKERS> attackers;
 	StaticVector<AttackStats, MAX_TRACKED_TARGETS> targets;
 
-	void EmplaceEnemy( const edict_t *enemy, int slot, const float *specifiedOrigin = nullptr );
-	void RemoveEnemy( Enemy &enemy );
+	void RemoveEnemy( Enemy *enemy );
 
-	void UpdateEnemyWeight( Enemy &enemy );
+	void UpdateEnemyWeight( Enemy *enemy );
 	float ComputeRawEnemyWeight( const edict_t *enemy );
 
 	// Returns attacker slot number
@@ -319,15 +352,77 @@ private:
 	bool hasShell;
 	float damageToBeKilled;
 
+	enum {
+		TRACKED_LIST_INDEX = Enemy::TRACKED_LIST_INDEX,
+		ACTIVE_LIST_INDEX = Enemy::ACTIVE_LIST_INDEX
+	};
+
+	inline void Link( Enemy *enemy, int listIndex ) {
+		assert( listIndex == TRACKED_LIST_INDEX || listIndex == ACTIVE_LIST_INDEX );
+
+		// If there is an existing list head, set its prev link to the newly linked enemy
+		if( Enemy *currHead = listHeads[listIndex] ) {
+			currHead->listLinks[listIndex].prev = enemy;
+		}
+
+		Enemy::Links *enemyLinks = &enemy->listLinks[listIndex];
+		// This is an "invariant" of list heads
+		enemyLinks->prev = nullptr;
+		// Set the next link of the newly linked enemy to the current head
+		enemyLinks->next = this->listHeads[listIndex];
+		// Set the list head to the newly linked enemy
+		this->listHeads[listIndex] = enemy;
+	}
+
+	inline void Unlink( Enemy *enemy, int listIndex ) {
+		assert( listIndex == TRACKED_LIST_INDEX || listIndex == ACTIVE_LIST_INDEX );
+
+		Enemy::Links *enemyLinks = &enemy->listLinks[listIndex];
+		// If a next enemy in list exists, set its prev link to the prev enemy of the unlinked enemy
+		if( Enemy *nextInList = enemyLinks->next ) {
+			nextInList->listLinks[listIndex].prev = enemyLinks->prev;
+		}
+
+		// If a prev enemy in list exists
+		if( Enemy *prevInList = enemyLinks->prev ) {
+			// The unlinked enemy must not be a list head
+			assert( enemy != this->listHeads[listIndex] );
+			// Set the prev enemy next link to the next enemy in list of the unlinked enemy
+			prevInList->listLinks[listIndex].next = enemyLinks->next;
+		} else {
+			// Make sure this is the list head
+			assert( enemy == this->listHeads[listIndex] );
+			// Update the list head using the next enemy in list of the unlinked enemy
+			this->listHeads[listIndex] = enemyLinks->next;
+		}
+
+		// Prevent using dangling links
+		enemyLinks->Clear();
+	}
+
 protected:
+	inline void LinkToTrackedList( Enemy *enemy ) {
+		Link( enemy, TRACKED_LIST_INDEX );
+	}
+
+	inline void UnlinkFromTrackedList( Enemy *enemy ) {
+		Unlink( enemy, TRACKED_LIST_INDEX );
+	}
+
+	inline void LinkToActiveList( Enemy *enemy ) {
+		Link( enemy, ACTIVE_LIST_INDEX );
+	}
+
+	inline void UnlinkFromActiveList( Enemy *enemy ) {
+		Unlink( enemy, ACTIVE_LIST_INDEX );
+	}
+
 	virtual void OnNewThreat( const edict_t *newThreat ) = 0;
 	virtual bool CheckHasQuad() const = 0;
 	virtual bool CheckHasShell() const = 0;
 	virtual void OnEnemyRemoved( const Enemy *enemy ) = 0;
 	// Used to compare enemy strength and pool owner
 	virtual float ComputeDamageToBeKilled() const = 0;
-	// Contains enemy eviction code
-	virtual void TryPushNewEnemy( const edict_t *enemy, const float *suggesedOrigin ) = 0;
 	// Overridden method may give some additional weight to an enemy
 	// (Useful for case when a bot should have some reinforcements)
 	virtual float GetAdditionalEnemyWeight( const edict_t *bot, const edict_t *enemy ) const = 0;
@@ -343,10 +438,9 @@ protected:
 	}
 
 	inline float AvgSkill() const { return avgSkill; }
-	inline float DecisionRandom() const { return decisionRandom; }
 
-	void TryPushEnemyOfSingleBot( const edict_t *bot, const edict_t *enemy, const float *specfiedOrigin = nullptr );
-
+	Enemy *TrackedEnemiesHead() { return listHeads[TRACKED_LIST_INDEX]; }
+	Enemy *ActiveEnemiesHead() { return listHeads[ACTIVE_LIST_INDEX]; }
 public:
 	AiBaseEnemyPool( float avgSkill_ );
 	virtual ~AiBaseEnemyPool() {}
@@ -354,11 +448,19 @@ public:
 	// If a weight is set > 0, this bot requires reinforcements
 	virtual void SetBotRoleWeight( const edict_t *bot, float weight ) = 0;
 
-	inline unsigned MaxTrackedEnemies() const { return maxTrackedEnemies; }
-	// Note that enemies in this array should be validated by IsValid() before access to their properties
-	inline const Enemy *TrackedEnemiesBuffer() const { return trackedEnemies; };
-	inline unsigned TrackedEnemiesBufferSize() const { return maxTrackedEnemies; }
-	inline const StaticVector<Enemy*, MAX_ACTIVE_ENEMIES> &ActiveEnemies() const { return activeEnemies; };
+	const Enemy *TrackedEnemiesHead() const { return listHeads[TRACKED_LIST_INDEX]; }
+	const Enemy *ActiveEnemiesHead() const { return listHeads[ACTIVE_LIST_INDEX]; }
+
+	unsigned NumTrackedEnemies() const { return numTrackedEnemies; }
+
+	const Enemy *EnemyForEntity( const edict_t *ent ) const {
+		return EnemyForEntity( ENTNUM( ent ) );
+	}
+
+	const Enemy *EnemyForEntity( int entNum ) const {
+		assert( (unsigned)entNum < MAX_EDICTS );
+		return entityToEnemyTable + entNum;
+	}
 
 	virtual void Frame() override;
 
@@ -396,5 +498,9 @@ public:
 
 inline int64_t Enemy::LastAttackedByTime() const { return parent->LastAttackedByTime( ent ); }
 inline float Enemy::TotalInflictedDamage() const { return parent->TotalDamageInflictedBy( ent ); }
+
+inline bool Enemy::IsInList( int listIndex ) const {
+	return listLinks[listIndex].next || listLinks[listIndex].prev || this == parent->listHeads[listIndex];
+}
 
 #endif

--- a/source/game/ai/ai_local.h
+++ b/source/game/ai/ai_local.h
@@ -279,4 +279,20 @@ public:
 	const T *end() const { return end_; }
 };
 
+// This is a compact storage for 64-bit values.
+// If an int64_t field is used in an array of tiny structs,
+// a substantial amount of space can be lost for alignment.
+class alignas ( 4 )Int64Align4 {
+	uint32_t parts[2];
+public:
+	operator int64_t() const {
+		return (int64_t)( ( (uint64_t)parts[0] << 32 ) | parts[1] );
+	}
+	Int64Align4 operator=( int64_t value ) {
+		parts[0] = (uint32_t)( ( (uint64_t)value >> 32 ) & 0xFFFFFFFFu );
+		parts[1] = (uint32_t)( ( (uint64_t)value >> 00 ) & 0xFFFFFFFFu );
+		return *this;
+	}
+};
+
 #endif

--- a/source/game/ai/ai_squad_based_team_brain.h
+++ b/source/game/ai/ai_squad_based_team_brain.h
@@ -112,7 +112,6 @@ protected:
 		virtual bool CheckHasShell() const override;
 		virtual float ComputeDamageToBeKilled() const override;
 		virtual void OnEnemyRemoved( const Enemy *enemy ) override;
-		virtual void TryPushNewEnemy( const edict_t *enemy, const float *suggestedOrigin ) override;
 
 		void SetBotRoleWeight( const edict_t *bot, float weight ) override;
 		float GetAdditionalEnemyWeight( const edict_t *bot, const edict_t *enemy ) const override;

--- a/source/game/ai/bot.cpp
+++ b/source/game/ai/bot.cpp
@@ -382,7 +382,7 @@ void Bot::UpdateKeptInFovPoint() {
 			lastChosenLostOrHiddenEnemyInstanceId++;
 		}
 
-		Vec3 origin( lostOrHiddenEnemy->LastSeenPosition() );
+		Vec3 origin( lostOrHiddenEnemy->LastSeenOrigin() );
 		if( !GetMiscTactics().shouldKeepXhairOnEnemy ) {
 			float distanceThreshold = 384.0f;
 			if( lostOrHiddenEnemy->ent ) {

--- a/source/game/ai/bot.h
+++ b/source/game/ai/bot.h
@@ -619,6 +619,8 @@ public:
 	SelectedMiscTactics &GetMiscTactics() { return botBrain.selectedTactics; }
 	const SelectedMiscTactics &GetMiscTactics() const { return botBrain.selectedTactics; }
 
+	const Danger *PrimaryDanger() const { return perceptionManager.PrimaryDanger(); }
+
 	inline bool WillAdvance() const { return botBrain.WillAdvance(); }
 	inline bool WillRetreat() const { return botBrain.WillRetreat(); }
 

--- a/source/game/ai/bot_brain.cpp
+++ b/source/game/ai/bot_brain.cpp
@@ -181,8 +181,9 @@ void BotBrain::UpdateSelectedEnemies() {
 	lostEnemies.Invalidate();
 	float visibleEnemyWeight = 0.0f;
 	if( const Enemy *visibleEnemy = activeEnemyPool->ChooseVisibleEnemy( self ) ) {
-		const auto &activeEnemies = activeEnemyPool->ActiveEnemies();
-		selectedEnemies.Set( visibleEnemy, targetChoicePeriod, activeEnemies.begin(), activeEnemies.end() );
+		// A compiler prefers a non-const version here, and therefore fails on non-const version of method being private
+		const auto *activeEnemiesHead = ( (const AiBaseEnemyPool *)activeEnemyPool )->ActiveEnemiesHead();
+		selectedEnemies.Set( visibleEnemy, targetChoicePeriod, activeEnemiesHead );
 		visibleEnemyWeight = 0.5f * ( visibleEnemy->AvgWeight() + visibleEnemy->MaxWeight() );
 	}
 	if( const Enemy *lostEnemy = activeEnemyPool->ChooseLostOrHiddenEnemy( self ) ) {

--- a/source/game/ai/bot_brain.h
+++ b/source/game/ai/bot_brain.h
@@ -142,6 +142,8 @@ class BotBrain : public AiBaseBrain
 		return true;
 	}
 
+	float ComputeEnemyAreasBlockingFactor( const Enemy *enemy, float damageToKillBot, int botBestWeaponTier );
+
 	void UpdateBlockedAreasStatus();
 
 	bool FindDodgeDangerSpot( const Danger &danger, vec3_t spotOrigin );

--- a/source/game/ai/bot_brain.h
+++ b/source/game/ai/bot_brain.h
@@ -186,9 +186,6 @@ protected:
 		bool CheckHasShell() const override { return ::HasShell( bot ); }
 		float ComputeDamageToBeKilled() const override { return DamageToKill( bot ); }
 		void OnEnemyRemoved( const Enemy *enemy ) override;
-		void TryPushNewEnemy( const edict_t *enemy, const float *suggestedOrigin ) override {
-			TryPushEnemyOfSingleBot( bot, enemy, suggestedOrigin );
-		}
 		void SetBotRoleWeight( const edict_t *bot_, float weight ) override {}
 		float GetAdditionalEnemyWeight( const edict_t *bot_, const edict_t *enemy ) const override { return 0; }
 		void OnBotEnemyAssigned( const edict_t *bot_, const Enemy *enemy ) override {}
@@ -234,8 +231,6 @@ public:
 	void OnNewThreat( const edict_t *newThreat, const AiFrameAwareUpdatable *threatDetector );
 	void OnEnemyRemoved( const Enemy *enemy );
 
-	inline unsigned MaxTrackedEnemies() const { return botEnemyPool.MaxTrackedEnemies(); }
-
 	void OnEnemyViewed( const edict_t *enemy );
 	void OnEnemyOriginGuessed( const edict_t *enemy, unsigned minMillisSinceLastSeen, const float *guessedOrigin = nullptr );
 
@@ -247,10 +242,10 @@ public:
 
 	// In these calls use not active but bot's own enemy pool
 	// (this behaviour is expected by callers, otherwise referring to a squad enemy pool is enough)
-	inline unsigned LastAttackedByTime( const edict_t *attacker ) const {
+	inline int64_t LastAttackedByTime( const edict_t *attacker ) const {
 		return botEnemyPool.LastAttackedByTime( attacker );
 	}
-	inline unsigned LastTargetTime( const edict_t *target ) const {
+	inline int64_t LastTargetTime( const edict_t *target ) const {
 		return botEnemyPool.LastTargetTime( target );
 	}
 

--- a/source/game/ai/bot_fire_target_cache.cpp
+++ b/source/game/ai/bot_fire_target_cache.cpp
@@ -443,7 +443,7 @@ void BotFireTargetCache::SetupCoarseFireTarget( const SelectedEnemies &selectedE
 		float weightsSum = 1.0f;
 		for( auto iter = snapshots.begin(), end = snapshots.end(); iter != end; ++iter ) {
 			const auto &snapshot = *iter;
-			unsigned timeDelta = (unsigned)( levelTime - snapshot.timestamp );
+			unsigned timeDelta = (unsigned)( levelTime - snapshot.Timestamp() );
 			// If snapshot is too outdated, stop accumulation
 			if( timeDelta > maxTimeDelta ) {
 				break;
@@ -451,12 +451,13 @@ void BotFireTargetCache::SetupCoarseFireTarget( const SelectedEnemies &selectedE
 
 			// Recent snapshots have greater weight
 			float weight = 1.0f - timeDelta * weightTimeDeltaScale;
-			const float *originData = snapshot.origin.Data();
-			const float *velocityData = snapshot.velocity.Data();
+			// We have to store these temporarily unpacked values in locals
+			Vec3 snapshotOrigin( snapshot.Origin() );
+			Vec3 snapshotVelocity( snapshot.Velocity() );
 			// Accumulate snapshot target origin using the weight
-			VectorMA( target, weight, originData, target );
+			VectorMA( target, weight, snapshotOrigin.Data(), target );
 			// Accumulate snapshot target velocity using the weight
-			VectorMA( velocity, weight, velocityData, velocity );
+			VectorMA( velocity, weight, snapshotVelocity.Data(), velocity );
 			weightsSum += weight;
 		}
 		float invWeightsSum = 1.0f / weightsSum;

--- a/source/game/ai/bot_items_selector.cpp
+++ b/source/game/ai/bot_items_selector.cpp
@@ -46,6 +46,17 @@ BotItemsSelector::ItemAndGoalWeights BotItemsSelector::ComputeItemWeights( const
 		case IT_ARMOR: return ComputeArmorWeights( item );
 		case IT_POWERUP: return ComputePowerupWeights( item );
 	}
+
+	// Collect ammo packs too.
+	// Checking an actual pack contents might sound better, but:
+	// 1) It complicates the item selection code that is likely to be reworked anyway.
+	// 2) It adds some degree of cheating (a bot knows exact pack contents in this case)
+	if( item->tag == AMMO_PACK || item->tag == AMMO_PACK_STRONG || item->tag == AMMO_PACK_WEAK ) {
+		// These weights are relatively large for this kind of item,
+		// but we guess ammo packs are valuable in gametypes where they might be dropped.
+		return ItemAndGoalWeights( 0.75f, 0.75f );
+	}
+
 	return ItemAndGoalWeights( 0, 0 );
 }
 

--- a/source/game/ai/bot_movement.cpp
+++ b/source/game/ai/bot_movement.cpp
@@ -6,6 +6,9 @@
 #ifndef PUBLIC_BUILD
 #define CHECK_ACTION_SUGGESTION_LOOPS
 #define ENABLE_MOVEMENT_ASSERTIONS
+#define CHECK_INFINITE_NEXT_STEP_LOOPS
+static int nextStepIterationsCounter = 0;
+static constexpr int NEXT_STEP_INFINITE_LOOP_THRESHOLD = 10000;
 #endif
 
 // Useful for debugging but freezes even Release version
@@ -223,8 +226,16 @@ bool BotMovementState::TestActualStatesForExpectedMask( unsigned expectedStatesM
 	// Might be set to null if verbose logging is not needed
 #ifdef ENABLE_MOVEMENT_DEBUG_OUTPUT
 	void ( *logFunc )( const char *format, ... ) = G_Printf;
+#elif defined( CHECK_INFINITE_NEXT_STEP_LOOPS )
+	void ( *logFunc )( const char *format, ... );
+	// Suppress output if the iterations counter is within a feasible range
+	if( ::nextStepIterationsCounter < NEXT_STEP_INFINITE_LOOP_THRESHOLD ) {
+		logFunc = nullptr;
+	} else {
+		logFunc = G_Printf;
+	}
 #else
-	void ( *logFunc )( const char *format, ... ) = nullptr;
+	void ( logFunc )( const char *format, ... ) = nullptr;
 #endif
 	constexpr const char *format = "BotMovementState(%s): %s %d has mismatch with the mask value\n";
 
@@ -1082,11 +1093,34 @@ void BotMovementPredictionContext::BuildPlan() {
 	this->sequenceStopReason = UNSPECIFIED;
 	this->isCompleted = false;
 	this->shouldRollback = false;
+
+#ifndef CHECK_INFINITE_NEXT_STEP_LOOPS
 	for(;; ) {
 		if( !NextPredictionStep() ) {
 			break;
 		}
 	}
+#else
+	::nextStepIterationsCounter = 0;
+	for(;; ) {
+		if( !NextPredictionStep() ) {
+			break;
+		}
+		++nextStepIterationsCounter;
+		if( nextStepIterationsCounter < NEXT_STEP_INFINITE_LOOP_THRESHOLD ) {
+			continue;
+		}
+		// An verbose output has been enabled at this stage
+		if( nextStepIterationsCounter < NEXT_STEP_INFINITE_LOOP_THRESHOLD + 200 ) {
+			continue;
+		}
+		constexpr const char *message =
+			"BotMovementPredictionContext::BuildPlan(): "
+			"an infinite NextPredictionStep() loop has been detected. "
+			"Check the server console output of last 200 steps\n";
+		G_Error( "%s", message );
+	}
+#endif
 
 	// The entity might be linked for some predicted state by Intercepted_PMoveTouchTriggers()
 	GClip_UnlinkEntity( self );
@@ -1209,7 +1243,14 @@ void BotMovementPredictionContext::NextMovementStep() {
 }
 
 void BotMovementPredictionContext::Debug( const char *format, ... ) const {
-#ifdef ENABLE_MOVEMENT_DEBUG_OUTPUT
+#if ( defined( ENABLE_MOVEMENT_DEBUG_OUTPUT ) || defined( CHECK_INFINITE_NEXT_STEP_LOOPS ) )
+// Check if there is an already detected error in this case and perform output only it the condition passes
+#if !defined( ENABLE_MOVEMENT_DEBUG_OUTPUT )
+	if( ::nextStepIterationsCounter < NEXT_STEP_INFINITE_LOOP_THRESHOLD ) {
+		return;
+	}
+#endif
+
 	char tag[64];
 	Q_snprintfz( tag, 64, "^6MovementPredictionContext(%s)", Nick( self ) );
 
@@ -1350,7 +1391,14 @@ inline BotLandOnSavedAreasMovementAction &BotBaseMovementAction::LandOnSavedArea
 }
 
 void BotBaseMovementAction::Debug( const char *format, ... ) const {
-#ifdef ENABLE_MOVEMENT_DEBUG_OUTPUT
+#if ( defined( ENABLE_MOVEMENT_DEBUG_OUTPUT ) || defined( CHECK_INFINITE_NEXT_STEP_LOOPS ) )
+// Check if there is an already detected error in this case and perform output only it the condition passes
+#if !defined( ENABLE_MOVEMENT_DEBUG_OUTPUT )
+	if( ::nextStepIterationsCounter < NEXT_STEP_INFINITE_LOOP_THRESHOLD ) {
+		return;
+	}
+#endif
+
 	char tag[128];
 	Q_snprintfz( tag, 128, "^5%s(%s)", this->Name(), Nick( self ) );
 

--- a/source/game/ai/bot_movement.cpp
+++ b/source/game/ai/bot_movement.cpp
@@ -4988,6 +4988,19 @@ void BotWalkCarefullyMovementAction::PlanPredictionStep( BotMovementPredictionCo
 	}
 }
 
+void BotWalkCarefullyMovementAction::CheckPredictionStepResults( BotMovementPredictionContext *context ) {
+	BotBaseMovementAction::CheckPredictionStepResults( context );
+	if( context->isCompleted ) {
+		return;
+	}
+
+	if( context->cannotApplyAction && context->shouldRollback ) {
+		Debug( "A prediction step has lead to rolling back, the action will be disabled for planning\n" );
+		this->isDisabledForPlanning = true;
+		return;
+	}
+}
+
 bool BotGenericRunBunnyingMovementAction::GenericCheckIsActionEnabled( BotMovementPredictionContext *context,
 																	   BotBaseMovementAction *suggestedAction ) {
 	if( !BotBaseMovementAction::GenericCheckIsActionEnabled( context, suggestedAction ) ) {

--- a/source/game/ai/bot_movement.cpp
+++ b/source/game/ai/bot_movement.cpp
@@ -1502,17 +1502,32 @@ void BotBaseMovementAction::CheckPredictionStepResults( BotMovementPredictionCon
 		}
 	}
 
-	if( this->failPredictionOnEnteringDangerImpactZone && !self->ai->botRef->ShouldRushHeadless() ) {
+	if( self->ai->botRef->ShouldRushHeadless() ) {
+		return;
+	}
+
+	if( this->failPredictionOnEnteringDangerImpactZone ) {
 		if( const auto *danger = self->ai->botRef->perceptionManager.PrimaryDanger() ) {
 			if( danger->SupportsImpactTests() ) {
-				if( !danger->HasImpactOnPoint( oldEntityPhysicsState.Origin() ) ) {
-					if( danger->HasImpactOnPoint( newEntityPhysicsState.Origin() ) ) {
+				// Check the new origin condition first to cut off early
+				if( danger->HasImpactOnPoint( newEntityPhysicsState.Origin() ) ) {
+					if( !danger->HasImpactOnPoint( oldEntityPhysicsState.Origin() ) ) {
 						Debug( "A prediction step has lead to entering a danger influence zone, should rollback\n" );
 						context->SetPendingRollback();
 						return;
 					}
 				}
 			}
+		}
+	}
+
+	// If misc tactics flag "rush headless" is set, areas occupied by enemies are never excluded from routing
+	const auto *routeCache = self->ai->botRef->routeCache;
+	// Check the new origin condition first to cut off early
+	if( routeCache->AreaTemporarilyDisabled( newAasAreaNum ) ) {
+		if( !routeCache->AreaTemporarilyDisabled( oldAasAreaNum ) ) {
+			Debug( "A prediction step has lead to entering a temporarily excluded from routing, should rollback\n" );
+			return;
 		}
 	}
 }

--- a/source/game/ai/bot_movement.h
+++ b/source/game/ai/bot_movement.h
@@ -1665,6 +1665,7 @@ class BotWalkCarefullyMovementAction : public BotBaseMovementAction
 public:
 	DECLARE_MOVEMENT_ACTION_CONSTRUCTOR( BotWalkCarefullyMovementAction, COLOR_RGB( 128, 0, 255 ) ) {}
 	void PlanPredictionStep( BotMovementPredictionContext *context ) override;
+	void CheckPredictionStepResults( BotMovementPredictionContext *context ) override;
 };
 
 class BotGenericRunBunnyingMovementAction : public BotBaseMovementAction

--- a/source/game/ai/bot_perception_manager.cpp
+++ b/source/game/ai/bot_perception_manager.cpp
@@ -1011,9 +1011,7 @@ void BotPerceptionManager::RegisterVisibleEnemies() {
 	}
 
 	StaticVector<uint16_t, MAX_CLIENTS> visibleTargets;
-	static_assert( AiBaseEnemyPool::MAX_TRACKED_ENEMIES <= MAX_CLIENTS, "targetsInPVS capacity may be exceeded" );
-
-	entitiesDetector.FilterRawEntitiesWithDistances( candidateTargets, visibleTargets, botBrain->MaxTrackedEnemies(),
+	entitiesDetector.FilterRawEntitiesWithDistances( candidateTargets, visibleTargets, MAX_CLIENTS,
 													 IsGenericEntityInPvs, IsEnemyVisible );
 
 	for( auto entNum: visibleTargets )
@@ -1261,22 +1259,6 @@ void BotPerceptionManager::HandleGenericPlayerEntityEvent( const edict_t *player
 		PushEnemyEventOrigin( player, player->s.origin );
 	}
 }
-
-// This is a compact storage for 64-bit values.
-// If an int64_t field is used in an array of tiny structs,
-// a substantial amount of space can be lost for alignment.
-class alignas ( 4 )Int64Align4 {
-	uint32_t parts[2];
-public:
-	operator int64_t() const {
-		return (int64_t)( ( (uint64_t)parts[0] << 32 ) | parts[1] );
-	}
-	Int64Align4 operator=( int64_t value ) {
-		parts[0] = (uint32_t)( ( (uint64_t)value >> 32 ) & 0xFFFFFFFFu );
-		parts[1] = (uint32_t)( ( (uint64_t)value >> 00 ) & 0xFFFFFFFFu );
-		return *this;
-	}
-};
 
 class CachedEventsToPlayersMap {
 	struct alignas ( 4 )Entry {

--- a/source/game/ai/bot_weapon_selector.cpp
+++ b/source/game/ai/bot_weapon_selector.cpp
@@ -172,7 +172,7 @@ float SelectedEnemies::ComputeThreatFactor( const edict_t *ent, int enemyNum ) c
 	// Try cutting off further expensive calls by doing this cheap test first
 	if( const auto *client = ent->r.client ) {
 		// Can't shoot soon.
-		if( client->ps.stats[STAT_WEAPON_TIME] > 500 ) {
+		if( client->ps.stats[STAT_WEAPON_TIME] > 800 ) {
 			return 0.0f;
 		}
 	}
@@ -204,6 +204,12 @@ float SelectedEnemies::ComputeThreatFactor( const edict_t *ent, int enemyNum ) c
 
 	if( ent->s.effects & ( EF_QUAD | EF_CARRIER ) ) {
 		return 1.0f;
+	}
+
+	if( const auto *danger = self->ai->botRef->PrimaryDanger() ) {
+		if( danger->attacker == ent ) {
+			return 0.5f + 0.5f * BoundedFraction( danger->damage, 75 );
+		}
 	}
 
 	// Its guaranteed that the enemy cannot hit

--- a/source/game/ai/bot_weapon_selector.h
+++ b/source/game/ai/bot_weapon_selector.h
@@ -157,8 +157,12 @@ public:
 
 	void Set( const Enemy *primaryEnemy_,
 			  unsigned timeoutPeriod,
-			  const Enemy *const *activeEnemiesBegin,
-			  const Enemy *const *activeEnemiesEnd );
+			  const Enemy **activeEnemiesBegin,
+			  const Enemy **activeEnemiesEnd );
+
+	void Set( const Enemy *primaryEnemy_,
+			  unsigned timeoutPeriod,
+			  const Enemy *firstActiveEnemy );
 
 	inline unsigned InstanceId() const { return instanceId; }
 
@@ -172,7 +176,7 @@ public:
 
 	Vec3 LastSeenOrigin() const {
 		CheckValid( __FUNCTION__ );
-		return primaryEnemy->LastSeenPosition();
+		return primaryEnemy->LastSeenOrigin();
 	}
 
 	Vec3 ActualOrigin() const {


### PR DESCRIPTION
This patch solves many positioning issues but is currently prone to producing infinite loops in bot movement prediction sometimes (probably an attempt to enter a blocked area rolls back prediction stack, then everything repeats). Once the known glitch is resolved this patch would get merged, and also a similar patch would arrive to the upstream.