### PR TITLE
Add aggressive culling options for client snaps

### DIFF
--- a/source/cgame/cg_screen.cpp
+++ b/source/cgame/cg_screen.cpp
@@ -869,11 +869,6 @@ void CG_DrawTeamMates( void ) {
 			continue;
 		}
 
-		// players might be SVF_FORCETEAM'ed for teammates, prevent ugly flickering for specs
-		if( cg.predictedPlayerState.stats[STAT_REALTEAM] == TEAM_SPECTATOR && !trap_CM_InPVS( cg.view.origin, cent->ent.origin ) ) {
-			continue;
-		}
-
 		// find the 3d point in 2d screen
 		trap_R_TransformVectorToScreen( &cg.view.refdef, drawOrigin, coords );
 		if( ( coords[0] < 0 || coords[0] > cgs.vidWidth ) || ( coords[1] < 0 || coords[1] > cgs.vidHeight ) ) {

--- a/source/game/CMakeLists.txt
+++ b/source/game/CMakeLists.txt
@@ -13,6 +13,7 @@ file(GLOB GAME_HEADERS
 	"../../third-party/recastnavigation/Recast/Include/*.h"
 	"../../third-party/recastnavigation/Detour/Include/*.h"
 	"../qcommon/net.h" # constants and types for address parsing
+	"../qcommon/snap.h" # constants for the antihack system
 )
 
 file(GLOB GAME_SOURCES

--- a/source/game/g_public.h
+++ b/source/game/g_public.h
@@ -41,6 +41,7 @@ typedef struct {
 	int ping;
 	int health;
 	int frags;
+	int snapHintFlags;
 } client_shared_t;
 
 typedef struct {

--- a/source/game/g_weapon.cpp
+++ b/source/game/g_weapon.cpp
@@ -1571,6 +1571,9 @@ static edict_t *_FindOrSpawnLaser( edict_t *owner, int entType, bool *newLaser )
 		laser->r.solid = SOLID_NOT;
 		laser->s.modelindex = 255; // needs to have some value so it isn't filtered by the server culling
 		laser->r.svflags &= ~SVF_NOCLIENT;
+		// The only real utility of this flag is to prevent aggressive entity culling by anticheat.
+		// The netcode/entity system needs an overhaul, use this hack as a temporary workaround.
+		laser->r.svflags |= SVF_TRANSMITORIGIN2;
 	}
 
 	return laser;

--- a/source/gameshared/q_shared.h
+++ b/source/gameshared/q_shared.h
@@ -287,7 +287,7 @@ void Info_CleanValue( const char *in, char *out, size_t outsize );
 //
 // per-level limits
 //
-#define MAX_CLIENTS                 256         // absolute limit
+#define MAX_CLIENTS                 64          // absolute limit
 #define MAX_EDICTS                  1024        // must change protocol to increase more
 #define MAX_LIGHTSTYLES             256
 #define MAX_MODELS                  1024        // these are sent over the net as shorts

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -141,53 +141,7 @@ void Com_FreePureList( purelist_t **purelist );
 
 //============================================================================
 
-#define SNAP_MAX_DEMO_META_DATA_SIZE    16 * 1024
-
-// define this 0 to disable compression of demo files
-#define SNAP_DEMO_GZ                    FS_GZ
-
-void SNAP_ParseBaseline( msg_t *msg, entity_state_t *baselines );
-void SNAP_SkipFrame( msg_t *msg, struct snapshot_s *header );
-struct snapshot_s *SNAP_ParseFrame( msg_t *msg, struct snapshot_s *lastFrame, int *suppressCount, struct snapshot_s *backup, entity_state_t *baselines, int showNet );
-
-void SNAP_WriteFrameSnapToClient( struct ginfo_s *gi, struct client_s *client, msg_t *msg, int64_t frameNum, int64_t gameTime,
-								  entity_state_t *baselines, struct client_entities_s *client_entities,
-								  int numcmds, gcommand_t *commands, const char *commandsData );
-
-// Use PVS culling for sounds.
-// Note: changes gameplay experience, use with caution.
-#define SNAP_HINT_CULL_SOUND_WITH_PVS     ( 1 )
-// Try determining visibility via raycasting in collision world.
-// Might lead to false negatives and heavy CPU load,
-// but overall is recommended to use in untrusted environments.
-#define SNAP_HINT_USE_RAYCAST_CULLING     ( 2 )
-// Cull entities that are not in the front hemisphere of viewer.
-// Currently it is a last hope against cheaters in an untrusted environment,
-// but would be useful for slowly-turning vehicles in future.
-#define SNAP_HINT_USE_VIEW_DIR_CULLING    ( 4 )
-// If an entity would have been culled without attached sound events,
-// but cannot be culled due to mentioned attachments presence,
-// transmit fake angles, etc. to confuse a wallhack user
-#define SNAP_HINT_SHADOW_EVENTS_DATA      ( 8 )
-
-void SNAP_BuildClientFrameSnap( struct cmodel_state_s *cms, struct ginfo_s *gi, int64_t frameNum, int64_t timeStamp,
-								struct fatvis_s *fatvis, struct client_s *client,
-								game_state_t *gameState, struct client_entities_s *client_entities,
-								bool relay, struct mempool_s *mempool, int snapHintFlags );
-
-void SNAP_FreeClientFrames( struct client_s *client );
-
-void SNAP_RecordDemoMessage( int demofile, msg_t *msg, int offset );
-int SNAP_ReadDemoMessage( int demofile, msg_t *msg );
-void SNAP_BeginDemoRecording( int demofile, unsigned int spawncount, unsigned int snapFrameTime,
-							  const char *sv_name, unsigned int sv_bitflags, purelist_t *purelist,
-							  char *configstrings, entity_state_t *baselines );
-void SNAP_StopDemoRecording( int demofile );
-void SNAP_WriteDemoMetaData( const char *filename, const char *meta_data, size_t meta_data_realsize );
-size_t SNAP_ClearDemoMeta( char *meta_data, size_t meta_data_max_size );
-size_t SNAP_SetDemoMetaKeyValue( char *meta_data, size_t meta_data_max_size, size_t meta_data_realsize,
-								 const char *key, const char *value );
-size_t SNAP_ReadDemoMetaData( int demofile, char *meta_data, size_t meta_data_size );
+#include "snap.h"
 
 //============================================================================
 

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -165,6 +165,10 @@ void SNAP_WriteFrameSnapToClient( struct ginfo_s *gi, struct client_s *client, m
 // Currently it is a last hope against cheaters in an untrusted environment,
 // but would be useful for slowly-turning vehicles in future.
 #define SNAP_HINT_USE_VIEW_DIR_CULLING    ( 4 )
+// If an entity would have been culled without attached sound events,
+// but cannot be culled due to mentioned attachments presence,
+// transmit fake angles, etc. to confuse a wallhack user
+#define SNAP_HINT_SHADOW_EVENTS_DATA      ( 8 )
 
 void SNAP_BuildClientFrameSnap( struct cmodel_state_s *cms, struct ginfo_s *gi, int64_t frameNum, int64_t timeStamp,
 								struct fatvis_s *fatvis, struct client_s *client,

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -154,10 +154,22 @@ void SNAP_WriteFrameSnapToClient( struct ginfo_s *gi, struct client_s *client, m
 								  entity_state_t *baselines, struct client_entities_s *client_entities,
 								  int numcmds, gcommand_t *commands, const char *commandsData );
 
+// Use PVS culling for sounds.
+// Note: changes gameplay experience, use with caution.
+#define SNAP_HINT_CULL_SOUND_WITH_PVS     ( 1 )
+// Try determining visibility via raycasting in collision world.
+// Might lead to false negatives and heavy CPU load,
+// but overall is recommended to use in untrusted environments.
+#define SNAP_HINT_USE_RAYCAST_CULLING     ( 2 )
+// Cull entities that are not in the front hemisphere of viewer.
+// Currently it is a last hope against cheaters in an untrusted environment,
+// but would be useful for slowly-turning vehicles in future.
+#define SNAP_HINT_USE_VIEW_DIR_CULLING    ( 4 )
+
 void SNAP_BuildClientFrameSnap( struct cmodel_state_s *cms, struct ginfo_s *gi, int64_t frameNum, int64_t timeStamp,
 								struct fatvis_s *fatvis, struct client_s *client,
 								game_state_t *gameState, struct client_entities_s *client_entities,
-								bool relay, struct mempool_s *mempool );
+								bool relay, struct mempool_s *mempool, int snapHintFlags );
 
 void SNAP_FreeClientFrames( struct client_s *client );
 

--- a/source/qcommon/snap.h
+++ b/source/qcommon/snap.h
@@ -1,0 +1,69 @@
+#ifndef QFUSION_SNAP_H
+#define QFUSION_SNAP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SNAP_MAX_DEMO_META_DATA_SIZE    16 * 1024
+
+// define this 0 to disable compression of demo files
+#define SNAP_DEMO_GZ                    FS_GZ
+
+void SNAP_ParseBaseline( struct msg_s *msg, entity_state_t *baselines );
+void SNAP_SkipFrame( struct msg_s *msg, struct snapshot_s *header );
+struct snapshot_s *SNAP_ParseFrame( struct msg_s *msg, struct snapshot_s *lastFrame, int *suppressCount,
+									struct snapshot_s *backup, entity_state_t *baselines, int showNet );
+
+void SNAP_WriteFrameSnapToClient( struct ginfo_s *gi, struct client_s *client, struct msg_s *msg,
+								  int64_t frameNum, int64_t gameTime,
+								  entity_state_t *baselines, struct client_entities_s *client_entities,
+								  int numcmds, gcommand_t *commands, const char *commandsData );
+
+// Use PVS culling for sounds.
+// Note: changes gameplay experience, use with caution.
+#define SNAP_HINT_CULL_SOUND_WITH_PVS     ( 1 )
+// Try determining visibility via raycasting in collision world.
+// Might lead to false negatives and heavy CPU load,
+// but overall is recommended to use in untrusted environments.
+#define SNAP_HINT_USE_RAYCAST_CULLING     ( 2 )
+// Cull entities that are not in the front hemisphere of viewer.
+// Currently it is a last hope against cheaters in an untrusted environment,
+// but would be useful for slowly-turning vehicles in future.
+#define SNAP_HINT_USE_VIEW_DIR_CULLING    ( 4 )
+// If an entity would have been culled without attached sound events,
+// but cannot be culled due to mentioned attachments presence,
+// transmit fake angles, etc. to confuse a wallhack user
+#define SNAP_HINT_SHADOW_EVENTS_DATA      ( 8 )
+
+// Names for vars corresponding to the hint flags
+#define SNAP_VAR_CULL_SOUND_WITH_PVS     ( "sv_snap_aggressive_sound_culling" )
+#define SNAP_VAR_USE_RAYCAST_CULLING     ( "sv_snap_players_raycast_culling" )
+#define SNAP_VAR_USE_VIEWDIR_CULLING     ( "sv_snap_aggressive_fov_culling" )
+#define SNAP_VAR_SHADOW_EVENTS_DATA      ( "sv_snap_shadow_events_data" )
+
+void SNAP_BuildClientFrameSnap( struct cmodel_state_s *cms, struct ginfo_s *gi, int64_t frameNum, int64_t timeStamp,
+								struct fatvis_s *fatvis, struct client_s *client,
+								game_state_t *gameState, struct client_entities_s *client_entities,
+								bool relay, struct mempool_s *mempool, int snapHintFlags );
+
+void SNAP_FreeClientFrames( struct client_s *client );
+
+void SNAP_RecordDemoMessage( int demofile, struct msg_s *msg, int offset );
+int SNAP_ReadDemoMessage( int demofile, struct msg_s *msg );
+void SNAP_BeginDemoRecording( int demofile, unsigned int spawncount, unsigned int snapFrameTime,
+							  const char *sv_name, unsigned int sv_bitflags, struct purelist_s *purelist,
+							  char *configstrings, entity_state_t *baselines );
+void SNAP_StopDemoRecording( int demofile );
+void SNAP_WriteDemoMetaData( const char *filename, const char *meta_data, size_t meta_data_realsize );
+size_t SNAP_ClearDemoMeta( char *meta_data, size_t meta_data_max_size );
+size_t SNAP_SetDemoMetaKeyValue( char *meta_data, size_t meta_data_max_size, size_t meta_data_realsize,
+								 const char *key, const char *value );
+size_t SNAP_ReadDemoMetaData( int demofile, char *meta_data, size_t meta_data_size );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/source/qcommon/snap_write.c
+++ b/source/qcommon/snap_write.c
@@ -31,12 +31,10 @@ static int64_t shadowedForClientAt[MAX_CLIENTS - 1][MAX_EDICTS];
 
 // Mark entity for shadowing
 static inline void SNAP_Shadow( const client_snapshot_t *frame, int entNum ) {
-	// TODO: Use POVnum?
 	shadowedForClientAt[frame->ps->playerNum][entNum] = frame->sentTimeStamp;
 }
 
 static inline bool SNAP_IsShadowed( const client_snapshot_t *frame, int entNum ) {
-	// TODO: Use POVnum?
 	return shadowedForClientAt[frame->ps->playerNum][entNum] == frame->sentTimeStamp;
 }
 
@@ -879,6 +877,11 @@ static bool SNAP_SnapCullEntity( cmodel_state_t *cms, edict_t *ent,
 
 	// send all entities
 	if( frame->allentities ) {
+		return false;
+	}
+
+	// we have decided to transmit (almost) everything for spectators
+	if( clent->r.client->ps.stats[STAT_REALTEAM] == TEAM_SPECTATOR ) {
 		return false;
 	}
 

--- a/source/qcommon/snap_write.c
+++ b/source/qcommon/snap_write.c
@@ -439,7 +439,189 @@ static bool SNAP_BitsCullEntity( cmodel_state_t *cms, edict_t *ent, uint8_t *bit
 	return true;    // not visible/audible
 }
 
-#define SNAP_PVSCullEntity( cms,fatpvs,ent ) SNAP_BitsCullEntity( cms,ent,fatpvs,ent->r.num_clusters )
+static bool SNAP_ViewDirCullEntity( const edict_t *clent, const edict_t *ent ) {
+	vec3_t viewDir;
+	AngleVectors( clent->s.angles, viewDir, NULL, NULL );
+
+	vec3_t toEntDir;
+	VectorSubtract( ent->s.origin, clent->s.origin, toEntDir );
+	return DotProduct( toEntDir, viewDir ) < 0;
+}
+
+static bool SNAP_Raycast( cmodel_state_t *cms, trace_t *trace, const vec3_t from, const vec3_t to ) {
+	CM_TransformedBoxTrace( cms, trace, (float *)from, (float *)to, vec3_origin, vec3_origin, NULL, MASK_SOLID, NULL, NULL );
+
+	if( trace->fraction == 1.0f ) {
+		return true;
+	}
+
+	if( !trace->contents & CONTENTS_TRANSLUCENT ) {
+		return false;
+	}
+
+	vec3_t rayDir;
+	VectorSubtract( to, from, rayDir );
+	VectorNormalize( rayDir );
+
+	// Do 8 attempts to continue tracing.
+	// It might seem that the threshold could be lower,
+	// but keep in mind situations like on wca1
+	// while looking behind a glass tube being behind a glass wall itself.
+	for( int i = 0; i < 8; ++i ) {
+		vec3_t rayStart;
+		VectorMA( trace->endpos, 2.0f, rayDir, rayStart );
+
+		CM_TransformedBoxTrace( cms, trace, rayStart, (float *)to, vec3_origin, vec3_origin, NULL, MASK_SOLID, NULL, NULL );
+
+		if( trace->fraction == 1.0f ) {
+			return true;
+		}
+
+		if( !( trace->contents & CONTENTS_TRANSLUCENT ) ) {
+			return false;
+		}
+	}
+
+	return false;
+}
+
+static inline void SNAP_GetRandomPointInBox( const vec3_t origin, const vec3_t mins, const vec3_t size, vec3_t result ) {
+	result[0] = origin[0] + mins[0] + random() * size[0];
+	result[1] = origin[1] + mins[1] + random() * size[1];
+	result[2] = origin[2] + mins[2] + random() * size[2];
+}
+
+static bool SNAP_TryCullEntityByRaycasting( cmodel_state_t *cms, edict_t *clent, const vec3_t vieworg, edict_t *ent ) {
+	// Currently only clients are supported
+	const gclient_t *entClient = ent->r.client;
+	if( !entClient ) {
+		return false;
+	}
+
+	const gclient_t *client = clent->r.client;
+	vec3_t clientViewOrigin;
+	VectorCopy( clent->s.origin, clientViewOrigin );
+	clientViewOrigin[2] += client->ps.viewheight;
+
+	// Should be an actual origin
+	if( !VectorCompare( clientViewOrigin, vieworg ) ) {
+		return false;
+	}
+
+	// Do not use vis culling for fast moving clients/entities due to being prone to glitches
+
+	const float *clientVelocity = client->ps.pmove.velocity;
+	float squareClientVelocity = VectorLengthSquared( clientVelocity );
+	if( squareClientVelocity > 1100 * 1100 ) {
+		return false;
+	}
+
+	const float *entityVelocity = ent->r.client->ps.pmove.velocity;
+	float squareEntityVelocity = VectorLengthSquared( entityVelocity );
+	if( squareEntityVelocity > 1100 * 1100 ) {
+		return false;
+	}
+
+	if( squareClientVelocity > 800 * 800 && squareEntityVelocity > 800 * 800 ) {
+		return false;
+	}
+
+	vec3_t to;
+	VectorCopy( ent->s.origin, to );
+
+	trace_t trace;
+	// Do a first raycast to the entity origin for a fast cutoff
+	if( SNAP_Raycast( cms, &trace, clientViewOrigin, to ) ) {
+		return false;
+	}
+
+	// Do a second raycast at the entity chest/eyes level
+	to[2] += entClient->ps.viewheight;
+	if( SNAP_Raycast( cms, &trace, clientViewOrigin, to ) ) {
+		return false;
+	}
+
+	// Test a random point in entity bounds now
+	SNAP_GetRandomPointInBox( ent->s.origin, ent->r.mins, ent->r.size, to );
+	if( SNAP_Raycast( cms, &trace, clientViewOrigin, to ) ) {
+		return false;
+	}
+
+	// Now try applying a cutoff of further extremely expensive computations using client viewangles.
+	// This could lead to some glitches but we try to vary cutoff threshold by ping.
+	// Even in case when a high-ping player turns instantly back,
+	// an info about most players that should be visible in his POV is still provided.
+
+	vec3_t viewDir;
+	AngleVectors( client->ps.viewangles, viewDir, NULL, NULL );
+	VectorNormalize( viewDir );
+
+	vec3_t toEntDir;
+	VectorSubtract( ent->s.origin, clientViewOrigin, toEntDir );
+	VectorNormalize( toEntDir );
+
+	float pingDotFactor = -client->r.ping / 400.0f;
+	if( DotProduct( viewDir, toEntDir ) < pingDotFactor ) {
+		return true;
+	}
+
+	// Test all bbox corners at the current position.
+	// Prevent missing a player that should be clearly visible.
+
+	vec3_t bounds[2];
+	// Shrink bounds by 2 units to avoid ending in a solid if the entity contacts some brushes.
+	for( int i = 0; i < 3; ++i ) {
+		bounds[0][i] = ent->r.mins[i] + 2.0f;
+		bounds[1][i] = ent->r.maxs[i] - 2.0f;
+	}
+
+	for( int i = 0; i < 8; ++i ) {
+		to[0] = ent->s.origin[0] + bounds[(i >> 2) & 1][0];
+		to[1] = ent->s.origin[1] + bounds[(i >> 1) & 1][1];
+		to[2] = ent->s.origin[2] + bounds[(i >> 0) & 1][2];
+		if( SNAP_Raycast( cms, &trace, clientViewOrigin, to ) ) {
+			return false;
+		}
+	}
+
+	// There is no need to extrapolate
+	if( squareClientVelocity < 10 * 10 && squareEntityVelocity < 10 * 10 ) {
+		return true;
+	}
+
+	// We might think about skipping culling for high-ping players but pings are easily mocked from a client side.
+	// The game is barely playable for really high pings anyway.
+
+	float xerpTimeSeconds = 0.001f * ( 100 + client->r.ping );
+	clamp_high( xerpTimeSeconds, 0.275f );
+
+	// We want to test the trajectory in "continuous" way.
+	// Use a fixed small trajectory step and adjust the timestep using it.
+	float timestep;
+	if( squareEntityVelocity > squareClientVelocity ) {
+		timestep = 24.0f / sqrtf( squareEntityVelocity );
+	} else {
+		timestep = 24.0f / sqrtf( squareClientVelocity );
+	}
+
+	float secondsAhead = 0.0f;
+	while( secondsAhead < xerpTimeSeconds ) {
+		secondsAhead += timestep;
+
+		vec3_t from;
+		vec3_t entOrigin;
+
+		VectorMA( clientViewOrigin, secondsAhead, clientVelocity, from );
+		VectorMA( ent->s.origin, secondsAhead, vec3_origin, entOrigin );
+
+		SNAP_GetRandomPointInBox( entOrigin, ent->r.mins, ent->r.size, to );
+		if( SNAP_Raycast( cms, &trace, from, to ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
 
 //=====================================================================
 
@@ -545,13 +727,33 @@ static bool SNAP_SnapCullSoundEntity( cmodel_state_t *cms, edict_t *ent, vec3_t 
 	return true;
 }
 
+static inline bool SNAP_IsSoundCullOnlyEntity( const edict_t *ent ) {
+	// If it is set explicitly
+	if( ent->r.svflags & SVF_SOUNDCULL ) {
+		return true;
+	}
+
+	// If there is no sound
+	if( !ent->s.sound ) {
+		return false;
+	}
+
+	// Check whether there is nothing else to transmit
+	return !ent->s.modelindex && !ent->s.events[0] && !ent->s.light && !ent->s.effects;
+}
+
 /*
 * SNAP_SnapCullEntity
 */
-static bool SNAP_SnapCullEntity( cmodel_state_t *cms, edict_t *ent, edict_t *clent, client_snapshot_t *frame, vec3_t vieworg, uint8_t *fatpvs ) {
+static bool SNAP_SnapCullEntity( cmodel_state_t *cms, edict_t *ent,
+								 edict_t *clent, client_snapshot_t *frame,
+								 vec3_t vieworg, uint8_t *fatpvs, int snapHintFlags ) {
 	uint8_t *areabits;
 	bool snd_cull_only;
 	bool snd_culled;
+	bool snd_use_pvs;
+	bool use_raycasting;
+	bool use_viewdir_culling;
 
 	// filters: this entity has been disabled for comunication
 	if( ent->r.svflags & SVF_NOCLIENT ) {
@@ -596,35 +798,99 @@ static bool SNAP_SnapCullEntity( cmodel_state_t *cms, edict_t *ent, edict_t *cle
 		}
 	}
 
-	snd_cull_only = false;
+	snd_cull_only = SNAP_IsSoundCullOnlyEntity( ent );
+
+	snd_use_pvs = ( snapHintFlags & SNAP_HINT_CULL_SOUND_WITH_PVS ) != 0;
+	use_raycasting = ( snapHintFlags & SNAP_HINT_USE_RAYCAST_CULLING ) != 0;
+	use_viewdir_culling = ( snapHintFlags & SNAP_HINT_USE_VIEW_DIR_CULLING ) != 0;
+
+	if( snd_use_pvs ) {
+		// Don't even bother about calling SnapCullSoundEntity() except the entity has only a sound to transmit
+		if( snd_cull_only ) {
+			if( SNAP_SnapCullSoundEntity( cms, ent, vieworg, ent->s.attenuation ) ) {
+				return true;
+			}
+		}
+
+		// Force PVS culling in all other cases
+		if( SNAP_BitsCullEntity( cms, ent, fatpvs, ent->r.num_clusters ) ) {
+			return true;
+		}
+
+		// Don't test sounds by raycasting
+		if( snd_cull_only ) {
+			return false;
+		}
+
+		// Check whether there is sound-like info to transfer
+		if( ent->s.sound || ent->s.events[0] ) {
+			// If sound attenuation is not sufficient to cutoff the entity
+			if( !SNAP_SnapCullSoundEntity( cms, ent, vieworg, ent->s.attenuation ) ) {
+				return false;
+			}
+		}
+
+		// Don't try doing additional culling for beams
+		if( ent->r.svflags & SVF_TRANSMITORIGIN2 ) {
+			return false;
+		}
+
+		if( use_raycasting && SNAP_TryCullEntityByRaycasting( cms, clent, vieworg, ent ) ) {
+			return true;
+		}
+
+		if( use_viewdir_culling && SNAP_ViewDirCullEntity( clent, ent ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
 	snd_culled = true;
 
-	// sound entities culling
-	if( ent->r.svflags & SVF_SOUNDCULL ) {
-		snd_cull_only = true;
-	}
-	// if not a sound entity but the entity is only a sound
-	else if( !ent->s.modelindex && !ent->s.events[0] && !ent->s.light && !ent->s.effects && ent->s.sound ) {
-		snd_cull_only = true;
-	}
-
 	// PVS culling alone may not be used on pure sounds, entities with
-	// events and regular entities emitting sounds
+	// events and regular entities emitting sounds, unless being explicitly specified
 	if( snd_cull_only || ent->s.events[0] || ent->s.sound ) {
 		snd_culled = SNAP_SnapCullSoundEntity( cms, ent, vieworg, ent->s.attenuation );
 	}
 
-	// pure sound emitters don't use PVS culling at all
+	// If there is nothing else to transmit aside a sound and the sound has been culled by distance.
 	if( snd_cull_only && snd_culled ) {
 		return true;
 	}
-	return snd_culled && SNAP_PVSCullEntity( cms, fatpvs, ent );    // cull by PVS
+
+	// If sound attenuation is not sufficient to cutoff the entity
+	if( !snd_culled ) {
+		return false;
+	}
+
+	if( SNAP_BitsCullEntity( cms, ent, fatpvs, ent->r.num_clusters ) ) {
+		return true;
+	}
+
+	// Don't try doing additional culling for beams
+	if( ent->r.svflags & SVF_TRANSMITORIGIN2 ) {
+		return false;
+	}
+
+	if( use_raycasting && SNAP_TryCullEntityByRaycasting( cms, clent, vieworg, ent ) ) {
+		return true;
+	}
+
+	if( use_viewdir_culling && SNAP_ViewDirCullEntity( clent, ent ) ) {
+		return true;
+	}
+
+	return false;
 }
 
 /*
 * SNAP_BuildSnapEntitiesList
 */
-static void SNAP_BuildSnapEntitiesList( cmodel_state_t *cms, ginfo_t *gi, edict_t *clent, vec3_t vieworg, vec3_t skyorg, uint8_t *fatpvs, client_snapshot_t *frame, snapshotEntityNumbers_t *entsList ) {
+static void SNAP_BuildSnapEntitiesList( cmodel_state_t *cms, ginfo_t *gi,
+										edict_t *clent, vec3_t vieworg, vec3_t skyorg,
+										uint8_t *fatpvs, client_snapshot_t *frame,
+										snapshotEntityNumbers_t *entsList, int snapHintFlags ) {
 	int leafnum = -1, clusternum = -1, clientarea = -1;
 	int entNum;
 	edict_t *ent;
@@ -669,7 +935,7 @@ static void SNAP_BuildSnapEntitiesList( cmodel_state_t *cms, ginfo_t *gi, edict_
 			ent = EDICT_NUM( entNum );
 			if( ent->r.svflags & SVF_PORTAL ) {
 				// merge visibility sets if portal
-				if( SNAP_SnapCullEntity( cms, ent, clent, frame, vieworg, fatpvs ) ) {
+				if( SNAP_SnapCullEntity( cms, ent, clent, frame, vieworg, fatpvs, snapHintFlags ) ) {
 					continue;
 				}
 
@@ -691,7 +957,7 @@ static void SNAP_BuildSnapEntitiesList( cmodel_state_t *cms, ginfo_t *gi, edict_
 		}
 
 		// always add the client entity, even if SVF_NOCLIENT
-		if( ( ent != clent ) && SNAP_SnapCullEntity( cms, ent, clent, frame, vieworg, fatpvs ) ) {
+		if( ( ent != clent ) && SNAP_SnapCullEntity( cms, ent, clent, frame, vieworg, fatpvs, snapHintFlags ) ) {
 			continue;
 		}
 
@@ -721,7 +987,7 @@ static void SNAP_BuildSnapEntitiesList( cmodel_state_t *cms, ginfo_t *gi, edict_
 void SNAP_BuildClientFrameSnap( cmodel_state_t *cms, ginfo_t *gi, int64_t frameNum, int64_t timeStamp,
 								fatvis_t *fatvis, client_t *client,
 								game_state_t *gameState, client_entities_t *client_entities,
-								bool relay, mempool_t *mempool ) {
+								bool relay, mempool_t *mempool, int snapHintFlags ) {
 	int e, i, ne;
 	vec3_t org;
 	edict_t *ent, *clent;
@@ -814,7 +1080,7 @@ void SNAP_BuildClientFrameSnap( cmodel_state_t *cms, ginfo_t *gi, int64_t frameN
 	//=============================
 	entsList.numSnapshotEntities = 0;
 	memset( entsList.entityAddedToSnapList, 0, sizeof( entsList.entityAddedToSnapList ) );
-	SNAP_BuildSnapEntitiesList( cms, gi, clent, org, fatvis->skyorg, fatvis->pvs, frame, &entsList );
+	SNAP_BuildSnapEntitiesList( cms, gi, clent, org, fatvis->skyorg, fatvis->pvs, frame, &entsList, snapHintFlags );
 
 	if( developer->integer ) {
 		int olde = -1;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -364,6 +364,7 @@ extern cvar_t *sv_snap_aggressive_sound_culling;
 extern cvar_t *sv_snap_raycast_players_culling;
 // "fov" sounds more clear than "view dir" though its not very accurate
 extern cvar_t *sv_snap_aggressive_fov_culling;
+extern cvar_t *sv_snap_shadow_events_data;
 
 //===========================================================
 

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -360,6 +360,11 @@ extern cvar_t *sv_mm_authkey;
 extern cvar_t *sv_mm_loginonly;
 extern cvar_t *sv_mm_debug_reportbots;
 
+extern cvar_t *sv_snap_aggressive_sound_culling;
+extern cvar_t *sv_snap_raycast_players_culling;
+// "fov" sounds more clear than "view dir" though its not very accurate
+extern cvar_t *sv_snap_aggressive_fov_culling;
+
 //===========================================================
 
 //
@@ -478,7 +483,7 @@ void SV_Status_f( void );
 // sv_ents.c
 //
 void SV_WriteFrameSnapToClient( client_t *client, msg_t *msg );
-void SV_BuildClientFrameSnap( client_t *client );
+void SV_BuildClientFrameSnap( client_t *client, int snapHintFlags );
 
 
 //

--- a/source/server/sv_demos.c
+++ b/source/server/sv_demos.c
@@ -73,7 +73,7 @@ void SV_Demo_WriteSnap( void ) {
 
 	MSG_Init( &msg, msg_buffer, sizeof( msg_buffer ) );
 
-	SV_BuildClientFrameSnap( &svs.demo.client );
+	SV_BuildClientFrameSnap( &svs.demo.client, 0 );
 
 	SV_WriteFrameSnapToClient( &svs.demo.client, &msg );
 

--- a/source/server/sv_main.c
+++ b/source/server/sv_main.c
@@ -98,6 +98,10 @@ cvar_t *sv_lastAutoUpdate;
 
 cvar_t *sv_demodir;
 
+cvar_t *sv_snap_aggressive_sound_culling;
+cvar_t *sv_snap_raycast_players_culling;
+cvar_t *sv_snap_aggressive_fov_culling;
+
 //============================================================================
 
 /*
@@ -1000,6 +1004,10 @@ void SV_Init( void ) {
 	}
 
 	svc.autoUpdateMinute = rand() % 60;
+
+	sv_snap_aggressive_sound_culling = Cvar_Get( "sv_snap_aggressive_sound_culling" , "0", CVAR_SERVERINFO | CVAR_ARCHIVE );
+	sv_snap_raycast_players_culling = Cvar_Get( "sv_snap_raycast_players_culling", "1", CVAR_SERVERINFO | CVAR_ARCHIVE );
+	sv_snap_aggressive_fov_culling = Cvar_Get( "sv_snap_aggressive_fov_culling", "0", CVAR_SERVERINFO | CVAR_ARCHIVE );
 
 	Com_Printf( "Game running at %i fps. Server transmit at %i pps\n", sv_fps->integer, sv_pps->integer );
 

--- a/source/server/sv_main.c
+++ b/source/server/sv_main.c
@@ -101,6 +101,7 @@ cvar_t *sv_demodir;
 cvar_t *sv_snap_aggressive_sound_culling;
 cvar_t *sv_snap_raycast_players_culling;
 cvar_t *sv_snap_aggressive_fov_culling;
+cvar_t *sv_snap_shadow_events_data;
 
 //============================================================================
 
@@ -1008,6 +1009,7 @@ void SV_Init( void ) {
 	sv_snap_aggressive_sound_culling = Cvar_Get( "sv_snap_aggressive_sound_culling" , "0", CVAR_SERVERINFO | CVAR_ARCHIVE );
 	sv_snap_raycast_players_culling = Cvar_Get( "sv_snap_raycast_players_culling", "1", CVAR_SERVERINFO | CVAR_ARCHIVE );
 	sv_snap_aggressive_fov_culling = Cvar_Get( "sv_snap_aggressive_fov_culling", "0", CVAR_SERVERINFO | CVAR_ARCHIVE );
+	sv_snap_shadow_events_data = Cvar_Get( "sv_snap_shadow_events_data", "1", CVAR_SERVERINFO | CVAR_ARCHIVE );
 
 	Com_Printf( "Game running at %i fps. Server transmit at %i pps\n", sv_fps->integer, sv_pps->integer );
 

--- a/source/server/sv_main.c
+++ b/source/server/sv_main.c
@@ -1006,10 +1006,10 @@ void SV_Init( void ) {
 
 	svc.autoUpdateMinute = rand() % 60;
 
-	sv_snap_aggressive_sound_culling = Cvar_Get( "sv_snap_aggressive_sound_culling" , "0", CVAR_SERVERINFO | CVAR_ARCHIVE );
-	sv_snap_raycast_players_culling = Cvar_Get( "sv_snap_raycast_players_culling", "1", CVAR_SERVERINFO | CVAR_ARCHIVE );
-	sv_snap_aggressive_fov_culling = Cvar_Get( "sv_snap_aggressive_fov_culling", "0", CVAR_SERVERINFO | CVAR_ARCHIVE );
-	sv_snap_shadow_events_data = Cvar_Get( "sv_snap_shadow_events_data", "1", CVAR_SERVERINFO | CVAR_ARCHIVE );
+	sv_snap_aggressive_sound_culling = Cvar_Get( SNAP_VAR_CULL_SOUND_WITH_PVS , "0", CVAR_SERVERINFO | CVAR_ARCHIVE );
+	sv_snap_raycast_players_culling = Cvar_Get( SNAP_VAR_USE_RAYCAST_CULLING, "1", CVAR_SERVERINFO | CVAR_ARCHIVE );
+	sv_snap_aggressive_fov_culling = Cvar_Get( SNAP_VAR_USE_VIEWDIR_CULLING, "0", CVAR_SERVERINFO | CVAR_ARCHIVE );
+	sv_snap_shadow_events_data = Cvar_Get( SNAP_VAR_SHADOW_EVENTS_DATA, "1", CVAR_SERVERINFO | CVAR_ARCHIVE );
 
 	Com_Printf( "Game running at %i fps. Server transmit at %i pps\n", sv_fps->integer, sv_pps->integer );
 

--- a/source/server/sv_send.c
+++ b/source/server/sv_send.c
@@ -413,6 +413,9 @@ static bool SV_SendClientDatagram( client_t *client ) {
 	if( sv_snap_aggressive_fov_culling->integer ) {
 		snapHintFlags |= SNAP_HINT_USE_VIEW_DIR_CULLING;
 	}
+	if( sv_snap_shadow_events_data->integer ) {
+		snapHintFlags |= SNAP_HINT_SHADOW_EVENTS_DATA;
+	}
 
 	// send over all the relevant entity_state_t
 	// and the player_state_t

--- a/source/server/sv_send.c
+++ b/source/server/sv_send.c
@@ -369,7 +369,7 @@ void SV_WriteFrameSnapToClient( client_t *client, msg_t *msg ) {
 /*
 * SV_BuildClientFrameSnap
 */
-void SV_BuildClientFrameSnap( client_t *client ) {
+void SV_BuildClientFrameSnap( client_t *client, int snapHintFlags ) {
 	vec_t *skyorg = NULL, origin[3];
 
 	if( sv.configstrings[CS_SKYBOX][0] != '\0' ) {
@@ -387,7 +387,7 @@ void SV_BuildClientFrameSnap( client_t *client ) {
 	SNAP_BuildClientFrameSnap( svs.cms, &sv.gi, sv.framenum, svs.gametime,
 							   &svs.fatvis, client, ge->GetGameState(),
 							   &svs.client_entities,
-							   false, sv_mempool );
+							   false, sv_mempool, snapHintFlags );
 	svs.fatvis.skyorg = NULL;
 }
 
@@ -403,9 +403,20 @@ static bool SV_SendClientDatagram( client_t *client ) {
 
 	SV_AddReliableCommandsToMessage( client, &tmpMessage );
 
+	int snapHintFlags = 0;
+	if( sv_snap_aggressive_sound_culling->integer ) {
+		snapHintFlags |= SNAP_HINT_CULL_SOUND_WITH_PVS;
+	}
+	if( sv_snap_raycast_players_culling->integer ) {
+		snapHintFlags |= SNAP_HINT_USE_RAYCAST_CULLING;
+	}
+	if( sv_snap_aggressive_fov_culling->integer ) {
+		snapHintFlags |= SNAP_HINT_USE_VIEW_DIR_CULLING;
+	}
+
 	// send over all the relevant entity_state_t
 	// and the player_state_t
-	SV_BuildClientFrameSnap( client );
+	SV_BuildClientFrameSnap( client, snapHintFlags );
 
 	SV_WriteFrameSnapToClient( client, &tmpMessage );
 

--- a/source/server/sv_send.c
+++ b/source/server/sv_send.c
@@ -403,7 +403,9 @@ static bool SV_SendClientDatagram( client_t *client ) {
 
 	SV_AddReliableCommandsToMessage( client, &tmpMessage );
 
-	int snapHintFlags = 0;
+	// Set snap hint flags to client-specific flags set by the game module
+	int snapHintFlags = client->edict->r.client->r.snapHintFlags;
+	// Add server global snap hint flags
 	if( sv_snap_aggressive_sound_culling->integer ) {
 		snapHintFlags |= SNAP_HINT_CULL_SOUND_WITH_PVS;
 	}

--- a/source/tv_server/tv_relay_client.c
+++ b/source/tv_server/tv_relay_client.c
@@ -74,7 +74,7 @@ void TV_Relay_BuildClientFrameSnap( relay_t *relay, client_t *client ) {
 	SNAP_BuildClientFrameSnap( relay->cms, &relay->gi, relay->framenum, relay->realtime, &relay->fatvis,
 							   client, relay->module_export->GetGameState( relay->module ),
 							   &relay->client_entities,
-							   true, tv_mempool );
+							   true, tv_mempool, 0 );
 
 	if( relay->playernum >= 0 ) {
 		client->edict->s = backup_state;


### PR DESCRIPTION
Currently lacks votable flags per client that override server defaults (other players can force flags being applied to a client if they suspect a player in cheating). I don't want to touch game module until MM integration is merged.