### PR TITLE
 Select appropriate CM code path dynamically 

### DIFF
--- a/source/client/Android.mk
+++ b/source/client/Android.mk
@@ -33,6 +33,7 @@ LOCAL_SRC_FILES := \
   qalgo/md5.c \
   qalgo/q_trie.c \
   $(addprefix qcommon/,$(notdir $(wildcard $(LOCAL_PATH)/qcommon/*.c))) \
+  $(addprefix qcommon/,$(notdir $(wildcard $(LOCAL_PATH)/qcommon/*.cpp))) \
   $(addprefix server/,$(notdir $(wildcard $(LOCAL_PATH)/server/*.c))) \
   unix/unix_fs.c \
   unix/unix_net.c \

--- a/source/client/CMakeLists.txt
+++ b/source/client/CMakeLists.txt
@@ -35,6 +35,7 @@ file(GLOB CLIENT_HEADERS
 
 file(GLOB CLIENT_COMMON_SOURCES
     "../qcommon/*.c"
+	"../qcommon/*.cpp"
     "../server/*.c"
     "*.c"
     "../gameshared/q_*.c"
@@ -191,6 +192,12 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(CLIENT_BINARY_TYPE "")
 
     set(BUNDLE_RESOURCES "")
+endif()
+
+if (MSVC)
+	set_source_files_properties("../qcommon/cm_trace_sse42.cpp" PROPERTIES COMPILE_FLAGS "/arch:AVX")
+else()
+	set_source_files_properties("../qcommon/cm_trace_sse42.cpp" PROPERTIES COMPILE_FLAGS "-msse4.2")
 endif()
 
 add_executable(${QFUSION_CLIENT_NAME} ${CLIENT_BINARY_TYPE} ${CLIENT_HEADERS} ${CLIENT_PLATFORM_HEADERS} ${CLIENT_COMMON_SOURCES} ${CLIENT_PLATFORM_SOURCES} ${BUNDLE_RESOURCES})

--- a/source/gameshared/q_arch.h
+++ b/source/gameshared/q_arch.h
@@ -361,7 +361,7 @@ typedef int socket_handle_t;
 #define HAVE__INTERLOCKED_API
 #endif
 
-#if ( defined __i386__ || defined __x86_64__ )
+#if ( defined __i386__ || defined __x86_64__ || defined( _M_IX86 ) || defined( _M_AMD64 ) || defined( _M_X64 ) )
 #include <immintrin.h>
 
 // Unfortunately MSVC does not define __SSEn__ macros (but defines __AVXn__ !),

--- a/source/gameshared/q_math.h
+++ b/source/gameshared/q_math.h
@@ -233,7 +233,7 @@ inline bool BoundsIntersect( const vec3_t mins1, const vec3_t maxs1, const vec3_
 #ifdef QF_SSE4_1
 	return (bool)_mm_testz_ps( orCmp, orCmp );
 #else
-	return _mm_movemask_epi8( _mm_cmpeq_epi32( (__m128i)orCmp, _mm_setzero_si128() ) ) == 0xFFFF;
+	return _mm_movemask_epi8( _mm_cmpeq_epi32( _mm_castps_si128( orCmp ), _mm_setzero_si128() ) ) == 0xFFFF;
 #endif
 
 #endif

--- a/source/qcommon/cm_main.c
+++ b/source/qcommon/cm_main.c
@@ -173,9 +173,6 @@ static void CM_Clear( cmodel_state_t *cms ) {
 	cms->map_name[0] = 0;
 
 	ClearBounds( cms->world_mins, cms->world_maxs );
-
-	cms->CM_TransformedBoxTrace = NULL;
-	cms->CM_TransformedPointContents = NULL;
 }
 
 /*
@@ -898,6 +895,8 @@ cmodel_state_t *CM_New( void *mempool ) {
 	cms->map_leafs = &cms->map_leaf_empty;
 	cms->map_areas = &cms->map_area_empty;
 	cms->map_entitystring = &cms->map_entitystring_empty;
+
+	cms->traceComputer = CM_GetTraceComputer( cms );
 
 	return cms;
 }

--- a/source/qcommon/cm_sample.c
+++ b/source/qcommon/cm_sample.c
@@ -1,0 +1,208 @@
+#include "qcommon.h"
+#include "cm_local.h"
+
+/*
+* CM_PointLeafnum
+*/
+int CM_PointLeafnum( cmodel_state_t *cms, const vec3_t p ) {
+	int num = 0;
+	cnode_t *node;
+
+	if( !cms->numplanes ) {
+		return 0; // sound may call this without map loaded
+
+	}
+	do {
+		node = cms->map_nodes + num;
+		num = node->children[PlaneDiff( p, node->plane ) < 0];
+	} while( num >= 0 );
+
+	return -1 - num;
+}
+
+/*
+* CM_BoxLeafnums
+*
+* Fills in a list of all the leafs touched
+*/
+static void CM_BoxLeafnums_r( cmodel_state_t *cms, int nodenum ) {
+	int s;
+	cnode_t *node;
+
+	while( nodenum >= 0 ) {
+		node = &cms->map_nodes[nodenum];
+		s = BOX_ON_PLANE_SIDE( cms->leaf_mins, cms->leaf_maxs, node->plane ) - 1;
+
+		if( s < 2 ) {
+			nodenum = node->children[s];
+			continue;
+		}
+
+		// go down both sides
+		if( cms->leaf_topnode == -1 ) {
+			cms->leaf_topnode = nodenum;
+		}
+		CM_BoxLeafnums_r( cms, node->children[0] );
+		nodenum = node->children[1];
+	}
+
+	if( cms->leaf_count < cms->leaf_maxcount ) {
+		cms->leaf_list[cms->leaf_count++] = -1 - nodenum;
+	}
+}
+
+/*
+* CM_BoxLeafnums
+*/
+int CM_BoxLeafnums( cmodel_state_t *cms, vec3_t mins, vec3_t maxs, int *list, int listsize, int *topnode ) {
+	cms->leaf_list = list;
+	cms->leaf_count = 0;
+	cms->leaf_maxcount = listsize;
+	cms->leaf_mins = mins;
+	cms->leaf_maxs = maxs;
+
+	cms->leaf_topnode = -1;
+
+	CM_BoxLeafnums_r( cms, 0 );
+
+	if( topnode ) {
+		*topnode = cms->leaf_topnode;
+	}
+
+	return cms->leaf_count;
+}
+
+/*
+* CM_BrushContents
+*/
+static inline int CM_BrushContents( cbrush_t *brush, vec3_t p ) {
+	int i;
+	cbrushside_t *brushside;
+
+	for( i = 0, brushside = brush->brushsides; i < brush->numsides; i++, brushside++ )
+		if( PlaneDiff( p, &brushside->plane ) > 0 ) {
+			return 0;
+		}
+
+	return brush->contents;
+}
+
+/*
+* CM_PatchContents
+*/
+static inline int CM_PatchContents( cface_t *patch, vec3_t p ) {
+	int i, c;
+	cbrush_t *facet;
+
+	for( i = 0, facet = patch->facets; i < patch->numfacets; i++, patch++ )
+		if( ( c = CM_BrushContents( facet, p ) ) ) {
+			return c;
+		}
+
+	return 0;
+}
+
+/*
+* CM_PointContents
+*/
+static int CM_PointContents( cmodel_state_t *cms, vec3_t p, cmodel_t *cmodel ) {
+	int i, superContents, contents;
+	int nummarkfaces, nummarkbrushes;
+	cface_t *patch, **markface;
+	cbrush_t *brush, **markbrush;
+
+	if( !cms->numnodes ) {  // map not loaded
+		return 0;
+	}
+
+	if( cmodel == cms->map_cmodels ) {
+		cleaf_t *leaf;
+
+		leaf = &cms->map_leafs[CM_PointLeafnum( cms, p )];
+		superContents = leaf->contents;
+
+		markbrush = leaf->markbrushes;
+		nummarkbrushes = leaf->nummarkbrushes;
+
+		markface = leaf->markfaces;
+		nummarkfaces = leaf->nummarkfaces;
+	} else {
+		superContents = ~0;
+
+		markbrush = cmodel->markbrushes;
+		nummarkbrushes = cmodel->nummarkbrushes;
+
+		markface = cmodel->markfaces;
+		nummarkfaces = cmodel->nummarkfaces;
+	}
+
+	contents = superContents;
+
+	for( i = 0; i < nummarkbrushes; i++ ) {
+		brush = markbrush[i];
+
+		// check if brush adds something to contents
+		if( contents & brush->contents ) {
+			if( !( contents &= ~CM_BrushContents( brush, p ) ) ) {
+				return superContents;
+			}
+		}
+	}
+
+	for( i = 0; i < nummarkfaces; i++ ) {
+		patch = markface[i];
+
+		// check if patch adds something to contents
+		if( contents & patch->contents ) {
+			if( BoundsIntersect( p, p, patch->mins, patch->maxs ) ) {
+				if( !( contents &= ~CM_PatchContents( patch, p ) ) ) {
+					return superContents;
+				}
+			}
+		}
+	}
+
+	return ~contents & superContents;
+}
+
+/*
+* CM_TransformedPointContents
+*
+* Handles offseting and rotation of the end points for moving and
+* rotating entities
+*/
+int CM_TransformedPointContents( cmodel_state_t *cms, vec3_t p, cmodel_t *cmodel, vec3_t origin, vec3_t angles ) {
+	vec3_t p_l;
+
+	if( !cms->numnodes ) { // map not loaded
+		return 0;
+	}
+
+	if( !cmodel || cmodel == cms->map_cmodels ) {
+		cmodel = cms->map_cmodels;
+		origin = vec3_origin;
+		angles = vec3_origin;
+	} else {
+		if( !origin ) {
+			origin = vec3_origin;
+		}
+		if( !angles ) {
+			angles = vec3_origin;
+		}
+	}
+
+	// subtract origin offset
+	VectorSubtract( p, origin, p_l );
+
+	// rotate start and end into the models frame of reference
+	if( ( angles[0] || angles[1] || angles[2] ) && !cmodel->builtin ) {
+		vec3_t temp;
+		mat3_t axis;
+
+		AnglesToAxis( angles, axis );
+		VectorCopy( p_l, temp );
+		Matrix3_TransformVector( axis, temp, p_l );
+	}
+
+	return CM_PointContents( cms, p_l, cmodel );
+}

--- a/source/qcommon/cm_trace.h
+++ b/source/qcommon/cm_trace.h
@@ -1,0 +1,87 @@
+#ifndef QFUSION_CM_TRACE_H
+#define QFUSION_CM_TRACE_H
+
+#include "qcommon.h"
+
+struct trace_s;
+struct cmodel_state_s;
+struct cbrush_s;
+struct cface_s;
+struct cmodel_s;
+
+// 1/32 epsilon to keep floating point happy
+#define DIST_EPSILON    ( 1.0f / 32.0f )
+#define RADIUS_EPSILON      1.0f
+
+struct CMTraceContext {
+	trace_t *trace;
+
+	vec3_t start, end;
+	vec3_t mins, maxs;
+	vec3_t startmins, endmins;
+	vec3_t startmaxs, endmaxs;
+	vec3_t absmins, absmaxs;
+	vec3_t extents;
+	vec3_t traceDir;
+	float boxRadius;
+
+#ifdef CM_USE_SSE
+	__m128 xmmAbsmins, xmmAbsmaxs;
+	// TODO: Add also xmm copies of trace dir/start once line distance test is vectorized
+	__m128 xmmClipBoxLookup[16];
+#endif
+
+	int contents;
+	bool ispoint;      // optimized case
+};
+
+struct CMTraceComputer {
+	struct cmodel_state_s *cms;
+
+	CMTraceComputer(): cms( nullptr ) {}
+
+	virtual void SetupCollideContext( CMTraceContext *tlc, trace_t *tr, const vec_t *start, const vec_t *end,
+									  const vec_t *mins, const vec_t *maxs, int brushmask );
+
+	virtual void SetupClipContext( CMTraceContext *tlc ) {}
+
+	virtual void CollideBox( CMTraceContext *tlc, void ( CMTraceComputer::*method )( CMTraceContext *, cbrush_s * ),
+							 cbrush_s **markbrushes, int nummarkbrushes, cface_s **markfaces, int nummarkfaces );
+
+
+	virtual void ClipBoxToLeaf( CMTraceContext *tlc, cbrush_s **markbrushes,
+								int nummarkbrushes, cface_s **markfaces, int nummarkfaces );
+
+	// Lets avoid making these calls virtual, there is a small but definite performance penalty
+	// (something around 5-10%s, and this really matter as all newly introduced engine features rely on fast CM raycasting).
+	// They still can be "overridden" for specialized implementations
+	// just by using explicitly qualified method with the same signature.
+	void TestBoxInBrush( CMTraceContext *tlc, cbrush_s *brush );
+	void ClipBoxToBrush( CMTraceContext *tlc, cbrush_s *brush );
+
+	void RecursiveHullCheck( CMTraceContext *tlc, int num, float p1f, float p2f, vec3_t p1, vec3_t p2 );
+
+	void Trace( trace_t *tr, const vec3_t start, const vec3_t end, const vec3_t mins,
+				const vec3_t maxs, cmodel_s *cmodel, int brushmask );
+};
+
+struct CMGenericTraceComputer final: public CMTraceComputer {};
+
+struct CMSse42TraceComputer final: public CMTraceComputer {
+	// Don't even bother about making prototypes if there is no attempt to compile SSE code
+	// (this should aid calls devirtualization)
+#ifdef CM_USE_SSE
+	void SetupCollideContext( CMTraceContext *tlc, trace_t *tr, const vec_t *start, const vec_t *end,
+							  const vec_t *mins, const vec_t *maxs, int brushmask ) override;
+
+	void SetupClipContext( CMTraceContext *tlc ) override;
+
+	void ClipBoxToLeaf( CMTraceContext *tlc, cbrush_s **markbrushes, int nummarkbrushes,
+						cface_s **markfaces, int nummarkfaces ) override;
+
+	// Overrides a base member by hiding it
+	void ClipBoxToBrush( CMTraceContext *tlc, cbrush_s *brush );
+#endif
+};
+
+#endif //QFUSION_CM_TRACE_H

--- a/source/qcommon/cm_trace_sse42.cpp
+++ b/source/qcommon/cm_trace_sse42.cpp
@@ -1,0 +1,247 @@
+#include "qcommon.h"
+#include "cm_local.h"
+#include "cm_trace.h"
+
+#ifdef CM_USE_SSE
+
+static inline bool CM_BoundsIntersect_SSE42( __m128 traceAbsmins, __m128 traceAbsmaxs,
+											 const vec4_t shapeMins, const vec4_t shapeMaxs ) {
+	// This version relies on fast unaligned loads, that's why it requires SSE4.
+	__m128 xmmShapeMins = _mm_loadu_ps( shapeMins );
+	__m128 xmmShapeMaxs = _mm_loadu_ps( shapeMaxs );
+
+	__m128 cmp1 = _mm_cmpge_ps( xmmShapeMins, traceAbsmaxs );
+	__m128 cmp2 = _mm_cmpge_ps( traceAbsmins, xmmShapeMaxs );
+	__m128 orCmp = _mm_or_ps( cmp1, cmp2 );
+
+	return _mm_movemask_epi8( _mm_cmpeq_epi32( _mm_castps_si128( orCmp ), _mm_setzero_si128() ) ) == 0xFFFF;
+}
+
+static inline bool CM_MightCollide_SSE42( const vec_bounds_t shapeMins,
+										  const vec_bounds_t shapeMaxs,
+										  const CMTraceContext *tlc ) {
+	return CM_BoundsIntersect_SSE42( tlc->xmmAbsmins, tlc->xmmAbsmaxs, shapeMins, shapeMaxs );
+}
+
+static inline bool CM_MightCollideInLeaf_SSE42( const vec_bounds_t shapeMins,
+												const vec_bounds_t shapeMaxs,
+												const vec_bounds_t shapeCenter,
+												float shapeRadius,
+												const CMTraceContext *tlc ) {
+	if( !CM_MightCollide_SSE42( shapeMins, shapeMaxs, tlc ) ) {
+		return false;
+	}
+
+	// TODO: Vectorize this part. This task is not completed for various reasons.
+
+	vec3_t centerToStart;
+	vec3_t proj, perp;
+
+	VectorSubtract( tlc->start, shapeCenter, centerToStart );
+	float projMagnitude = DotProduct( centerToStart, tlc->traceDir );
+	VectorScale( tlc->traceDir, projMagnitude, proj );
+	VectorSubtract( centerToStart, proj, perp );
+	float distanceThreshold = shapeRadius + tlc->boxRadius;
+	return VectorLengthSquared( perp ) <= distanceThreshold * distanceThreshold;
+}
+
+void CMSse42TraceComputer::ClipBoxToLeaf( CMTraceContext *tlc, cbrush_t **markbrushes,
+										  int nummarkbrushes, cface_t **markfaces, int nummarkfaces ) {
+	int i, j;
+	cbrush_t *b;
+	cface_t *patch;
+	cbrush_t *facet;
+
+	// Save the exact address to avoid pointer chasing in loops
+	const float *fraction = &tlc->trace->fraction;
+
+	// trace line against all brushes
+	for( i = 0; i < nummarkbrushes; i++ ) {
+		b = markbrushes[i];
+		if( b->checkcount == cms->checkcount ) {
+			continue; // already checked this brush
+		}
+		b->checkcount = cms->checkcount;
+		if( !( b->contents & tlc->contents ) ) {
+			continue;
+		}
+		if( !CM_MightCollideInLeaf_SSE42( b->mins, b->maxs, b->center, b->radius, tlc ) ) {
+			continue;
+		}
+		// Specify the "overridden" method explicitly
+		CMSse42TraceComputer::ClipBoxToBrush( tlc, b );
+		if( !*fraction ) {
+			return;
+		}
+	}
+
+	// trace line against all patches
+	for( i = 0; i < nummarkfaces; i++ ) {
+		patch = markfaces[i];
+		if( patch->checkcount == cms->checkcount ) {
+			continue; // already checked this patch
+		}
+		patch->checkcount = cms->checkcount;
+		if( !( patch->contents & tlc->contents ) ) {
+			continue;
+		}
+		if( !CM_MightCollideInLeaf_SSE42( patch->mins, patch->maxs, patch->center, patch->radius, tlc ) ) {
+			continue;
+		}
+		facet = patch->facets;
+		for( j = 0; j < patch->numfacets; j++, facet++ ) {
+			if( !CM_MightCollideInLeaf_SSE42( facet->mins, facet->maxs, facet->center, facet->radius, tlc ) ) {
+				continue;
+			}
+			// Specify the "overridden" method explicitly
+			CMSse42TraceComputer::ClipBoxToBrush( tlc, facet );
+			if( !*fraction ) {
+				return;
+			}
+		}
+	}
+}
+
+void CMSse42TraceComputer::ClipBoxToBrush( CMTraceContext *tlc, cbrush_t *brush ) {
+	cm_plane_t *p, *clipplane;
+	cbrushside_t *side, *leadside;
+	float d1, d2, f;
+
+	if( !brush->numsides ) {
+		return;
+	}
+
+	float enterfrac = -1;
+	float leavefrac = 1;
+	clipplane = NULL;
+
+	bool getout = false;
+	bool startout = false;
+	leadside = NULL;
+	side = brush->brushsides;
+
+	const float *startmins = tlc->startmins;
+	const float *endmins = tlc->endmins;
+
+	for( int i = 0, end = brush->numsides; i < end; i++, side++ ) {
+		p = &side->plane;
+		int type = p->type;
+		float dist = p->dist;
+
+		// push the plane out apropriately for mins/maxs
+		if( type < 3 ) {
+			d1 = startmins[type] - dist;
+			d2 = endmins[type] - dist;
+		} else {
+			// It looks ugly but its better to inline two "DotProductSSE" calls to group similar ops together
+			__m128 *lookup = tlc->xmmClipBoxLookup + p->signbits * 2;
+			__m128 xmmNormal = _mm_loadu_ps( p->normal );
+			__m128 xmmDot1 = _mm_mul_ps( lookup[0], xmmNormal );
+			__m128 xmmDot2 = _mm_mul_ps( lookup[1], xmmNormal );
+			// https://stackoverflow.com/a/35270026
+			__m128 xmmShuf1 = _mm_movehdup_ps( xmmDot1 );    // broadcast elements 3,1 to 2,0
+			__m128 xmmShuf2 = _mm_movehdup_ps( xmmDot2 );
+			__m128 xmmSums1 = _mm_add_ps( xmmDot1, xmmShuf1 );
+			__m128 xmmSums2 = _mm_add_ps( xmmDot2, xmmShuf2 );
+			xmmShuf1 = _mm_movehl_ps( xmmShuf1, xmmSums1 );          // high half -> low half
+			xmmShuf2 = _mm_movehl_ps( xmmShuf2, xmmSums2 );
+			xmmSums1 = _mm_add_ss( xmmSums1, xmmShuf1 );
+			xmmSums2 = _mm_add_ss( xmmSums2, xmmShuf2 );
+			d1 = _mm_cvtss_f32( xmmSums1 ) - dist;
+			d2 = _mm_cvtss_f32( xmmSums2 ) - dist;
+		}
+
+		if( d2 > 0 ) {
+			getout = true; // endpoint is not in solid
+		}
+		if( d1 > 0 ) {
+			startout = true;
+		}
+
+		// if completely in front of face, no intersection
+		if( d1 > 0 && d2 >= d1 ) {
+			return;
+		}
+		if( d1 <= 0 && d2 <= 0 ) {
+			continue;
+		}
+		// crosses face
+		f = d1 - d2;
+		if( f > 0 ) {   // enter
+			f = ( d1 - DIST_EPSILON ) / f;
+			if( f > enterfrac ) {
+				enterfrac = f;
+				clipplane = p;
+				leadside = side;
+			}
+		} else if( f < 0 ) {   // leave
+			f = ( d1 + DIST_EPSILON ) / f;
+			if( f < leavefrac ) {
+				leavefrac = f;
+			}
+		}
+	}
+
+	if( !startout ) {
+		// original point was inside brush
+		tlc->trace->startsolid = true;
+		tlc->trace->contents = brush->contents;
+		if( !getout ) {
+			tlc->trace->allsolid = true;
+			tlc->trace->fraction = 0;
+		}
+		return;
+	}
+	if( enterfrac - ( 1.0f / 1024.0f ) <= leavefrac ) {
+		if( enterfrac > -1 && enterfrac < tlc->trace->fraction ) {
+			if( enterfrac < 0 ) {
+				enterfrac = 0;
+			}
+			tlc->trace->fraction = enterfrac;
+			CM_CopyCMToRawPlane( clipplane, &tlc->trace->plane );
+			tlc->trace->surfFlags = leadside->surfFlags;
+			tlc->trace->contents = brush->contents;
+		}
+	}
+}
+
+void CMSse42TraceComputer::SetupClipContext( CMTraceContext *tlc ) {
+	// Note: Using setR is important here, otherwise components order is ... surprising
+	// (We're going to compute dot products with vectors loaded via _mm_loadu_ps that preserve array elements order)
+
+	tlc->xmmClipBoxLookup[0] = _mm_setr_ps( tlc->startmins[0], tlc->startmins[1], tlc->startmins[2], 0 );
+	tlc->xmmClipBoxLookup[1] = _mm_setr_ps( tlc->endmins[0], tlc->endmins[1], tlc->endmins[2], 0 );
+
+	tlc->xmmClipBoxLookup[2] = _mm_setr_ps( tlc->startmaxs[0], tlc->startmins[1], tlc->startmins[2], 0 );
+	tlc->xmmClipBoxLookup[3] = _mm_setr_ps( tlc->endmaxs[0], tlc->endmins[1], tlc->endmins[2], 0 );
+
+	tlc->xmmClipBoxLookup[4] = _mm_setr_ps( tlc->startmins[0], tlc->startmaxs[1], tlc->startmins[2], 0 );
+	tlc->xmmClipBoxLookup[5] = _mm_setr_ps( tlc->endmins[0], tlc->endmaxs[1], tlc->endmins[2], 0 );
+
+	tlc->xmmClipBoxLookup[6] = _mm_setr_ps( tlc->startmaxs[0], tlc->startmaxs[1], tlc->startmins[2], 0 );
+	tlc->xmmClipBoxLookup[7] = _mm_setr_ps( tlc->endmaxs[0], tlc->endmaxs[1], tlc->endmins[2], 0 );
+
+	tlc->xmmClipBoxLookup[8] = _mm_setr_ps( tlc->startmins[0], tlc->startmins[1], tlc->startmaxs[2], 0 );
+	tlc->xmmClipBoxLookup[9] = _mm_setr_ps( tlc->endmins[0], tlc->endmins[1], tlc->endmaxs[2], 0 );
+
+	tlc->xmmClipBoxLookup[10] = _mm_setr_ps( tlc->startmaxs[0], tlc->startmins[1], tlc->startmaxs[2], 0 );
+	tlc->xmmClipBoxLookup[11] = _mm_setr_ps( tlc->endmaxs[0], tlc->endmins[1], tlc->endmaxs[2], 0 );
+
+	tlc->xmmClipBoxLookup[12] = _mm_setr_ps( tlc->startmins[0], tlc->startmaxs[1], tlc->startmaxs[2], 0 );
+	tlc->xmmClipBoxLookup[13] = _mm_setr_ps( tlc->endmins[0], tlc->endmaxs[1], tlc->endmaxs[2], 0 );
+
+	tlc->xmmClipBoxLookup[14] = _mm_setr_ps( tlc->startmaxs[0], tlc->startmaxs[1], tlc->startmaxs[2], 0 );
+	tlc->xmmClipBoxLookup[15] = _mm_setr_ps( tlc->endmaxs[0], tlc->endmaxs[1], tlc->endmaxs[2], 0 );
+}
+
+void CMSse42TraceComputer::SetupCollideContext( CMTraceContext *tlc, trace_t *tr,
+												const vec_t *start, const vec3_t end,
+												const vec3_t mins, const vec3_t maxs, int brushmask ) {
+	CMTraceComputer::SetupCollideContext( tlc, tr, start, end, mins, maxs, brushmask );
+
+	// Always set xmm trace bounds since it is used by all code paths, leaf-optimized and generic
+	tlc->xmmAbsmins = _mm_setr_ps( tlc->absmins[0], tlc->absmins[1], tlc->absmins[2], 0 );
+	tlc->xmmAbsmaxs = _mm_setr_ps( tlc->absmaxs[0], tlc->absmaxs[1], tlc->absmaxs[2], 1 );
+}
+
+#endif

--- a/source/qcommon/cmodel.h
+++ b/source/qcommon/cmodel.h
@@ -18,10 +18,11 @@
 
  */
 
-typedef struct cmodel_state_s cmodel_state_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-// debug/performance counter vars
-int c_pointcontents, c_traces, c_brush_traces;
+typedef struct cmodel_state_s cmodel_state_t;
 
 struct cmodel_s *CM_LoadMap( cmodel_state_t *cms, const char *name, bool clientload, unsigned *checksum );
 struct cmodel_s *CM_InlineModel( cmodel_state_t *cms, int num ); // 1, 2, etc
@@ -37,6 +38,7 @@ const char *CM_ShaderrefName( cmodel_state_t *cms, int ref );
 // creates a clipping hull for an arbitrary bounding box
 struct cmodel_s *CM_ModelForBBox( cmodel_state_t *cms, vec3_t mins, vec3_t maxs );
 struct cmodel_s *CM_OctagonModelForBBox( cmodel_state_t *cms, vec3_t mins, vec3_t maxs );
+
 void CM_InlineModelBounds( cmodel_state_t *cms, struct cmodel_s *cmodel, vec3_t mins, vec3_t maxs );
 
 // returns an ORed contents mask
@@ -76,6 +78,7 @@ bool CM_LeafsInPVS( cmodel_state_t *cms, int leafnum1, int leafnum2 );
 
 //
 cmodel_state_t *CM_New( void *mempool );
+
 void CM_AddReference( cmodel_state_t *cms );
 void CM_ReleaseReference( cmodel_state_t *cms );
 
@@ -88,3 +91,7 @@ cmodel_state_t *CM_Clone( cmodel_state_t *cms );
 //
 void CM_Init( void );
 void CM_Shutdown( void );
+
+#ifdef __cplusplus
+}
+#endif

--- a/source/qcommon/common.c
+++ b/source/qcommon/common.c
@@ -59,7 +59,6 @@ static cvar_t *logconsole = NULL;
 static cvar_t *logconsole_append;
 static cvar_t *logconsole_flush;
 static cvar_t *logconsole_timestamp;
-static cvar_t *com_showtrace;
 static cvar_t *com_introPlayed3;
 
 static qmutex_t *com_print_mutex;
@@ -858,7 +857,6 @@ void Qcommon_Init( int argc, char **argv ) {
 	logconsole_flush =  Cvar_Get( "logconsole_flush", "0", CVAR_ARCHIVE );
 	logconsole_timestamp =  Cvar_Get( "logconsole_timestamp", "0", CVAR_ARCHIVE );
 
-	com_showtrace =     Cvar_Get( "com_showtrace", "0", 0 );
 	com_introPlayed3 =   Cvar_Get( "com_introPlayed3", "0", CVAR_ARCHIVE );
 
 	Cvar_Get( "gamename", APPLICATION, CVAR_READONLY );
@@ -948,14 +946,6 @@ void Qcommon_Frame( unsigned int realMsec ) {
 		extratime = ( extratime + (float)realMsec * timescale->value ) - (float)gameMsec;
 	} else {
 		gameMsec = realMsec;
-	}
-
-	if( com_showtrace->integer ) {
-		Com_Printf( "%4i traces %4i brush traces %4i points\n",
-					c_traces, c_brush_traces, c_pointcontents );
-		c_traces = 0;
-		c_brush_traces = 0;
-		c_pointcontents = 0;
 	}
 
 	wswcurl_perform();

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -38,6 +38,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 //#define	PARANOID			// speed sapping error checking
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //============================================================================
 
 struct mempool_s;
@@ -999,5 +1003,9 @@ void Com_Autoupdate_Init( void );
 void Com_Autoupdate_Run( bool checkOnly, void ( *newfiles_cb )( void ) );
 void Com_Autoupdate_Cancel( void );
 void Com_Autoupdate_Shutdown( void );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // __QCOMMON_H

--- a/source/qcommon/qcommon.h
+++ b/source/qcommon/qcommon.h
@@ -900,13 +900,12 @@ CPU FEATURES
 ==============================================================
 */
 
-#define QCPU_HAS_RDTSC      0x00000001
-#define QCPU_HAS_MMX        0x00000002
-#define QCPU_HAS_MMXEXT     0x00000004
-#define QCPU_HAS_3DNOW      0x00000010
-#define QCPU_HAS_3DNOWEXT   0x00000020
-#define QCPU_HAS_SSE        0x00000040
-#define QCPU_HAS_SSE2       0x00000080
+// Query only features that seem to have some utility for the code base
+
+#define QF_CPU_FEATURE_SSE2    ( 0x1 )
+#define QF_CPU_FEATURE_SSE41   ( 0x2 )
+#define QF_CPU_FEATURE_SSE42   ( 0x4 )
+#define QF_CPU_FEATURE_AVX     ( 0x8 )
 
 unsigned int COM_CPUFeatures( void );
 

--- a/source/server/CMakeLists.txt
+++ b/source/server/CMakeLists.txt
@@ -17,12 +17,12 @@ file(GLOB SERVER_HEADERS
 
 file(GLOB SERVER_SOURCES
 	"../qcommon/asyncstream.c"
-	"../qcommon/autoupdate.c"	
-    "../qcommon/cm_main.c"
-	"../qcommon/cm_q1bsp.c"
-	"../qcommon/cm_q2bsp.c"
-    "../qcommon/cm_q3bsp.c"
-    "../qcommon/cm_trace.c"
+	"../qcommon/autoupdate.c"
+	"../qcommon/cm_main.c"
+	"../qcommon/cm_q3bsp.c"
+	"../qcommon/cm_sample.c"
+	"../qcommon/cm_trace.cpp"
+	"../qcommon/cm_trace_sse42.cpp"
 	"../qcommon/compression.c"	
     "../qcommon/bsp.c"
     "../qcommon/patch.c"
@@ -82,6 +82,12 @@ else()
 
     set(SERVER_PLATFORM_LIBRARIES "pthread" "dl" "m")
     set(SERVER_BINARY_TYPE "")
+endif()
+
+if (MSVC)
+	set_source_files_properties("../qcommon/cm_trace_sse42.cpp" PROPERTIES COMPILE_FLAGS "/arch:AVX")
+else()
+	set_source_files_properties("../qcommon/cm_trace_sse42.cpp" PROPERTIES COMPILE_FLAGS "-msse4.2")
 endif()
 
 add_executable(${QFUSION_SERVER_NAME} ${SERVER_BINARY_TYPE} ${SERVER_HEADERS} ${SERVER_SOURCES} ${SERVER_PLATFORM_SOURCES})

--- a/source/tv_server/CMakeLists.txt
+++ b/source/tv_server/CMakeLists.txt
@@ -15,10 +15,10 @@ file(GLOB TV_SERVER_SOURCES
 	"../qcommon/asyncstream.c"
 	"../qcommon/autoupdate.c"
 	"../qcommon/cm_main.c"
-	"../qcommon/cm_q1bsp.c"
-	"../qcommon/cm_q2bsp.c"
-    "../qcommon/cm_q3bsp.c"
-    "../qcommon/cm_trace.c"
+	"../qcommon/cm_q3bsp.c"
+	"../qcommon/cm_sample.c"
+	"../qcommon/cm_trace.cpp"
+	"../qcommon/cm_trace_sse42.cpp"
 	"../qcommon/compression.c"
     "../qcommon/bsp.c"
     "../qcommon/patch.c"
@@ -79,6 +79,12 @@ else()
 
     set(TV_SERVER_PLATFORM_LIBRARIES "pthread" "dl" "m")
     set(TV_SERVER_BINARY_TYPE "")
+endif()
+
+if (MSVC)
+	set_source_files_properties("../qcommon/cm_trace_sse42.cpp" PROPERTIES COMPILE_FLAGS "/arch:AVX")
+else()
+	set_source_files_properties("../qcommon/cm_trace_sse42.cpp" PROPERTIES COMPILE_FLAGS "-msse4.2")
 endif()
 
 add_executable(${QFUSION_TVSERVER_NAME} ${TV_SERVER_BINARY_TYPE} ${TV_SERVER_HEADERS} ${TV_SERVER_SOURCES} ${TV_SERVER_PLATFORM_SOURCES})


### PR DESCRIPTION
Quick benchmark using https://gist.github.com/dnk777/3744e1fb34005e2aad38f77ec967dcd6

```
        | generic | SSE 4.2
simpsons_q3  ------------------------
Bench1  | 28.6  | 20.0
Bench2  | 20.0  | 16.0
wdm7 ----------------------------------
Bench1  | 15.2  | 12.8
Bench2  | 16.8  | 15.7
wca1 ----------------------------------             
Bench1  | 8.6   |  5.8
Bench2  | 16.1  | 13.3
```
SSE4.2 support is not really required by the used instruction set, but its support practically guarantees fast unaligned SSE loads.

The generic version however still uses SSE2 comparisons too in `BoundsIntersects()` which itself gives something like 25% of speedup.