### PR TITLE
Fix debug build.

### DIFF
--- a/source/qcommon/cm_q3bsp.c
+++ b/source/qcommon/cm_q3bsp.c
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define MAX_FACET_PLANES 32
 
-inline float CM_AddSphericalBounds( vec_bounds_t mins, vec_bounds_t maxs, vec_bounds_t center ) {
+static inline float CM_AddSphericalBounds( vec_bounds_t mins, vec_bounds_t maxs, vec_bounds_t center ) {
 #ifdef CM_USE_SSE
 	mins[3] = 0.0f;
 	maxs[3] = 1.0f;


### PR DESCRIPTION
With `CMAKE_BUILD_TYPE=Debug` `CM_AddSphericalBounds` becomes an undefined reference without `static`.