### PR TITLE
AI: Fix nasty class layout issue for MSVC

### DIFF
--- a/source/game/ai/awareness/AlertTracker.h
+++ b/source/game/ai/awareness/AlertTracker.h
@@ -3,6 +3,7 @@
 
 #include "../ai_local.h"
 #include "../static_vector.h"
+#include "../ai_frame_aware_updatable.h"
 
 /**
  * An alert spot definition that is visible for scripts
@@ -26,7 +27,6 @@ struct AiAlertSpot {
 		, carrierEnemyInfluenceScale( carrierEnemyInfluenceScale_ ) {}
 };
 
-class AiFrameAwareUpdatable;
 class Bot;
 
 /**


### PR DESCRIPTION
Background: https://stackoverflow.com/a/30924216

Details: In MSVC The sizeof

```
typedef void (AiFrameAwareUpdatable::*AlertCallback )( Bot *detector, int spotId,
float alertLevel );
```

depends on wheter `AiFrameAwareUpdatable` is only forward declared, or the full class declaration is present at the time `AlertCallback` processed by the compiler.

When `AiFrameAwareUpdatable` is only forward declared the `sizeof(AlertCallback)` will be 24 bytes.

In the other case where the full `AiFrameAwareUpdatable` class declaration is available before `AlertCallback` it will be 8 bytes.

The issue was that in `bot.cpp` and `ai_manager.cpp` the include order was different: `class AiFrameAwareUpdatable` being forward declared for `AlertCallback` in one case and not in the other. Thus leading to different values for `sizeof(Bot)`.