### PR TITLE
q_libc: Avoid undefined behaviour with ctype functions.

### DIFF
--- a/source/common/helpers/q_libc.cpp
+++ b/source/common/helpers/q_libc.cpp
@@ -536,7 +536,7 @@ char *Q_strupr( char *s ) {
 
 	if( s ) {
 		for( p = s; *s; s++ )
-			*s = toupper( *s );
+			*s = toupper( ( unsigned char )*s );
 		return p;
 	}
 
@@ -551,7 +551,7 @@ char *Q_strlwr( char *s ) {
 
 	if( s ) {
 		for( p = s; *s; s++ )
-			*s = tolower( *s );
+			*s = tolower( ( unsigned char )*s );
 		return p;
 	}
 


### PR DESCRIPTION
The argument of these functions is of type int, but only a very restricted subset of values are actually valid.  The argument must either be the value of the macro EOF (which has a negative value), or must be a non-negative value within the range representable as unsigned char. Passing invalid values leads to undefined behavior.

Fixes a segmentation fault on NetBSD 11.